### PR TITLE
Add EnableRootMappingByIDWithZone and DisableRootMappingByIDWithZone

### DIFF
--- a/exports.go
+++ b/exports.go
@@ -205,6 +205,30 @@ func (c *Client) EnableRootMappingByID(
 	return apiv2.ExportUpdate(ctx, c.API, nex)
 }
 
+// EnableRootMappingByID enables the root mapping for an Export.
+func (c *Client) EnableRootMappingByIDWithZone(
+	ctx context.Context, id int, zone, user string) error {
+
+	ex, err := c.GetExportByIDWithZone(ctx, id, zone)
+	if err != nil {
+		return err
+	}
+	if ex == nil {
+		return nil
+	}
+
+	nex := &apiv2.Export{ID: ex.ID, MapRoot: ex.MapRoot}
+
+	setUserMapping(
+		nex,
+		user,
+		true,
+		func(e Export) UserMapping { return e.MapRoot },
+		func(e Export, m UserMapping) { e.MapRoot = m })
+
+	return apiv2.ExportUpdate(ctx, c.API, nex)
+}
+
 // DisableRootMapping disables the root mapping for an Export.
 func (c *Client) DisableRootMapping(
 	ctx context.Context, name string) error {
@@ -234,6 +258,30 @@ func (c *Client) DisableRootMappingByID(
 	ctx context.Context, id int) error {
 
 	ex, err := c.GetExportByID(ctx, id)
+	if err != nil {
+		return err
+	}
+	if ex == nil {
+		return nil
+	}
+
+	nex := &apiv2.Export{ID: ex.ID, MapRoot: ex.MapRoot}
+
+	setUserMapping(
+		nex,
+		"nobody",
+		false,
+		func(e Export) UserMapping { return e.MapRoot },
+		func(e Export, m UserMapping) { e.MapRoot = m })
+
+	return apiv2.ExportUpdate(ctx, c.API, nex)
+}
+
+// DisableRootMappingByID disables the root mapping for an Export.
+func (c *Client) DisableRootMappingByIDWithZone(
+	ctx context.Context, id int, zone string) error {
+
+	ex, err := c.GetExportByIDWithZone(ctx, id, zone)
 	if err != nil {
 		return err
 	}

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,7 @@
 module github.com/dell/goisilon
 
+go 1.14
+
 require (
 	github.com/akutz/gournal v0.5.0
 	github.com/sirupsen/logrus v1.4.2

--- a/go.sum
+++ b/go.sum
@@ -14,6 +14,7 @@ github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.4.0 h1:2E4SXV/wtOkTonXsotYi4li6zVWxYlZuYNCXe9XRJyk=
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
+golang.org/x/sys v0.0.0-20190422165155-953cdadca894 h1:Cz4ceDQGXuKRnVBDTS23GTn/pU5OE2C0WrNTOYK1Uuc=
 golang.org/x/sys v0.0.0-20190422165155-953cdadca894/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v2 v2.2.2 h1:ZCJp+EgiOT7lHqUV2J862kp8Qj64Jo6az82+3Td9dZw=


### PR DESCRIPTION
I'm working on a patch for https://github.com/dell/csi-isilon that requires *ByIDWithZone versions of EnableRootMapping and DisableRootMapping to be symmetric with other API calls.

This pull request adds the missing functions.

See also: #4 