### PR TITLE
Update args needed for gosec to run

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -13,6 +13,9 @@ jobs:
         uses: actions/checkout@v2
       - name: Run Go Security
         uses: securego/gosec@master
+        with:
+          # added additional exclude arguments after gosec v2.9.4 came out
+          args: -exclude=G104,G402,G101 ./...
   malware_security_scan:
     name: Malware Scanner
     runs-on: ubuntu-latest


### PR DESCRIPTION
By default gosec expects args without it it defaults to -h option and lists the way to run gosec and does not run any actual test.

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
https://github.com/dell/csm/issues/128

# Common PR Checklist:

- [x] Have you made sure that the code compiles?
- [ ] Have you commented your code, particularly in hard-to-understand areas
- [x] Did you run tests in a real Kubernetes cluster?
- [ ] Have you maintained backward compatibility

## Description of your changes:
Add arguments for gosec.
Exclusions are:
1. G104 (CWE-703): Errors unhandled -> We have WriteByte('"') and similar functions which have existed for long and adding and err check in all 85 places is not needed.
2. G402 (CWE-295): TLS InsecureSkipVerify set true -> We have an option to choose secure or insecure TLS depending on which type of client is requested, hence ignoring it. and also there is an ask to have MinVersion: tls.VersionTLS12 or above.
3.  G101 (CWE-798): Potential hardcoded credentials ->  >  headerISICSRFToken                    = "X-CSRF-Token"
     It flags any word with token as hardcoded credentials.

