### PR TITLE
Added numeric = true parameter for faster response

### DIFF
--- a/api/v3/api_v3_cluster.go
+++ b/api/v3/api_v3_cluster.go
@@ -49,10 +49,13 @@ func GetIsiStats(
 	return resp, err
 }
 
+// IsIOInProgress returns the list of clients currently performing IO on the particular array
 func IsIOInProgress(ctx context.Context,
 	client api.Client) (resp *ExportClientList, err error) {
 	err = client.Get(
-		ctx, string(platfromStatsPath), "summary/client", nil,
+		ctx, string(platfromStatsPath), "summary/client", api.OrderedValues{
+			{[]byte("numeric"), []byte("true")}, // numeric=true returns the response faster since it does not performs reverse lookup and returns IP addresses
+		},
 		nil,
 		&resp)
 	return resp, err


### PR DESCRIPTION
# PR Submission checklist

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
| https://github.com/dell/csm/issues/262 |

# Common PR Checklist:

- [x] Have you made sure that the code compiles?
- [x] Have you commented your code, particularly in hard-to-understand areas
- [x] Did you run tests in a real Kubernetes cluster?
- [x] Have you maintained backward compatibility

## Description of your changes:
Added a parameter numeric = true to the existing statistic API for IOinProgress to optimize the same.
