### PR TITLE
Fix query quota call by path

### DIFF
--- a/api/v11/api_v11_replication.go
+++ b/api/v11/api_v11_replication.go
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2022 Dell Inc, or its subsidiaries.
+Copyright (c) 2022-2023 Dell Inc, or its subsidiaries.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -82,6 +82,7 @@ type Policy struct {
 	Id           string    `json:"id,omitempty"`
 	Name         string    `json:"name,omitempty"`
 	Enabled      bool      `json:"enabled"`
+	Conflicted   bool      `json:"conflicted"`
 	TargetPath   string    `json:"target_path,omitempty"`
 	SourcePath   string    `json:"source_root_path,omitempty"`
 	TargetHost   string    `json:"target_host,omitempty"`
@@ -137,6 +138,7 @@ type Report struct {
 	JobId   int64     `json:"job_id"`
 	State   JOB_STATE `json:"state,omitempty"`
 	EndTime int64     `json:"end_time"`
+	Errors  []string  `json:"errors"`
 }
 
 // GetPolicyByName returns policy by name

--- a/env.sh
+++ b/env.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Copyright © 2019-2022 Dell Inc. or its subsidiaries. All Rights Reserved.
+# Copyright © 2019-2023 Dell Inc. or its subsidiaries. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -18,6 +18,7 @@ GOISILON_USERNAME="admin"
 GOISILON_GROUP=""
 GOISILON_PASSWORD="admin"
 GOISILON_INSECURE="true"
+GOISILON_UNRESOLVABLE_HOSTS="false"
 GOISILON_VOLUMEPATH="/ifs/data/csi"
 GOISILON_VOLUMEPATH_PERMISSIONS="0777"
 GOISILON_AUTHTYPE=0

--- a/exports_test.go
+++ b/exports_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2022 Dell Inc, or its subsidiaries.
+Copyright (c) 2022-2023 Dell Inc, or its subsidiaries.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -347,13 +347,13 @@ func TestAddExportClientsByID(t *testing.T) {
 }
 
 func testAddExportClientsByID(t *testing.T, exportID int, export Export, addExportClientsByID func(
-	ctx context.Context, id int, clients []string) error) {
+	ctx context.Context, id int, clients []string, ignoreUnresolvableHosts bool) error) {
 
 	var clientsToAdd = []string{"192.168.1.110", "192.168.1.110", "192.168.1.111", "192.168.1.112", "192.168.1.113"}
 
 	log.Debug(defaultCtx, "add '%v' to '%v' for export '%d'", clientsToAdd, *export.Clients, exportID)
 
-	err = addExportClientsByID(defaultCtx, exportID, clientsToAdd)
+	err = addExportClientsByID(defaultCtx, exportID, clientsToAdd, false)
 	assert.Nil(t, err)
 }
 
@@ -372,8 +372,8 @@ func TestRemoveExportClientsByName(t *testing.T) {
 }
 
 func testRemoveExportClients(t *testing.T,
-	removeExportClientsByIDFunc func(ctx context.Context, id int, clientsToRemove []string) error,
-	removeExportClientsByNameFunc func(ctx context.Context, name string, clientsToRemove []string) error) {
+	removeExportClientsByIDFunc func(ctx context.Context, id int, clientsToRemove []string, ignoreUnresolvableHosts bool) error,
+	removeExportClientsByNameFunc func(ctx context.Context, name string, clientsToRemove []string, ignoreUnresolvableHosts bool) error) {
 
 	volumeName1 := "test_get_exports1"
 
@@ -388,10 +388,10 @@ func testRemoveExportClients(t *testing.T,
 	log.Debug(defaultCtx, "remove '%v' from '%v' for export '%d'", clientsToRemove, *export.Clients, exportID)
 
 	if removeExportClientsByIDFunc != nil {
-		err = removeExportClientsByIDFunc(defaultCtx, exportID, clientsToRemove)
+		err = removeExportClientsByIDFunc(defaultCtx, exportID, clientsToRemove, false)
 		assert.Nil(t, err)
 	} else {
-		err = removeExportClientsByNameFunc(defaultCtx, exportName, clientsToRemove)
+		err = removeExportClientsByNameFunc(defaultCtx, exportName, clientsToRemove, false)
 		assert.Nil(t, err)
 	}
 

--- a/goisilon_test.go
+++ b/goisilon_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2019-2022 Dell Inc, or its subsidiaries.
+Copyright (c) 2019-2023 Dell Inc, or its subsidiaries.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -64,8 +64,14 @@ func TestMain(m *testing.M) {
 	if err != nil {
 		log.WithError(err).Panic(defaultCtx, "error fetching environment variable GOISILON_INSECURE")
 	}
-
+	ignoreUnresolvableHosts, err := strconv.ParseBool(os.Getenv("GOISILON_UNRESOLVABLE_HOSTS"))
+	if err != nil {
+		log.WithError(err).Panic(defaultCtx, "error fetching environment variable GOISILON_UNRESOLVABLE_HOSTS")
+	}
 	authType, err := strconv.Atoi(os.Getenv("GOISILON_AUTHTYPE"))
+	if err != nil {
+		log.WithError(err).Panic(defaultCtx, "error fetching environment variable GOISILON_AUTHTYPE")
+	}
 
 	client, err = NewClientWithArgs(
 		defaultCtx,
@@ -77,15 +83,12 @@ func TestMain(m *testing.M) {
 		os.Getenv("GOISILON_PASSWORD"),
 		os.Getenv("GOISILON_VOLUMEPATH"),
 		os.Getenv("GOISILON_VOLUMEPATH_PERMISSIONS"),
+		ignoreUnresolvableHosts,
 		uint8(authType))
-
 	if err != nil {
 		log.WithError(err).Panic(defaultCtx, "error creating test client")
 	}
 
-	if err != nil {
-		log.WithError(err).Panic(defaultCtx, "error creating test client")
-	}
 	os.Exit(m.Run())
 }
 

--- a/replication.go
+++ b/replication.go
@@ -1,7 +1,7 @@
 package goisilon
 
 /*
-Copyright (c) 2021-2022 Dell Inc, or its subsidiaries.
+Copyright (c) 2021-2023 Dell Inc, or its subsidiaries.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -18,6 +18,8 @@ limitations under the License.
 
 import (
 	"context"
+	"fmt"
+	"strings"
 	"time"
 
 	log "github.com/akutz/gournal"
@@ -27,6 +29,12 @@ import (
 
 const defaultPoll = 5 * time.Second
 const defaultTimeout = 10 * time.Minute // set high timeout, we expect to be canceled via context before
+
+const retryInterval = 15 * time.Second
+const maxRetries = 40 // with 15 sec, it is 4 retries per min. For 10 minutes, it is 40 retries
+const retryablePolicyError = "is in an error state. Please resolve it and retry"
+const retryableReportError = "A new quota domain that has not finished QuotaScan has been found"
+const resolveErrorToIgnore = "The policy was not conflicted, so no change was made"
 
 const (
 	RESYNC_PREP            apiv11.JOB_ACTION              = "resync_prep"
@@ -139,6 +147,23 @@ func (c *Client) ModifyPolicy(ctx context.Context, name string, schedule string,
 	} else if schedule == "when-source-modified" {
 		p.Schedule = schedule
 		p.JobDelay = rpo
+	}
+
+	return apiv11.UpdatePolicy(ctx, c.API, p)
+}
+
+// Resolves the policy that is in error state due to QuotaScan requirement.
+func (c *Client) ResolvePolicy(ctx context.Context, name string) error {
+	pp, err := c.GetPolicyByName(ctx, name)
+	if err != nil {
+		return err
+	}
+
+	p := &apiv11.Policy{
+		Id:         pp.Id,
+		Conflicted: false,
+		Enabled:    pp.Enabled,  // keep existing enabled state, otherwise it will be cleared
+		Schedule:   pp.Schedule, // keep existing schedule, otherwise it will be cleared
 	}
 
 	return apiv11.UpdatePolicy(ctx, c.API, p)
@@ -319,7 +344,7 @@ func (c *Client) SyncPolicy(ctx context.Context, policyName string) error {
 		return err
 	}
 	if !policy.Enabled {
-		return nil
+		return fmt.Errorf("cannot run sync on disabled policy %s", policyName)
 	}
 
 	runningJobs, err := c.GetJobsByPolicyName(ctx, policyName)
@@ -334,7 +359,7 @@ func (c *Client) SyncPolicy(ctx context.Context, policyName string) error {
 		}
 	}
 	if isRunning {
-		log.Info(ctx, "found active jobs, waiting for completion")
+		log.Info(ctx, "found active jobs -SL-, waiting for completion")
 		err = c.WaitForNoActiveJobs(ctx, policyName)
 		if err != nil {
 			return err
@@ -345,10 +370,42 @@ func (c *Client) SyncPolicy(ctx context.Context, policyName string) error {
 			Id: policyName,
 		}
 		log.Info(ctx, "found no active sync jobs, starting a new one")
-		_, err := c.StartSyncIQJob(ctx, jobReq)
-		if err != nil {
-			return err
+
+		// workaround for PowerScale KB article
+		// https://www.dell.com/support/kbdoc/en-us/000019414/quotas-on-synciq-source-directories
+		for i := 0; i < maxRetries; i++ {
+			_, err := c.StartSyncIQJob(ctx, jobReq)
+			if err == nil {
+				break
+			}
+			if strings.Contains(err.Error(), retryablePolicyError) {
+				if i+1 == maxRetries {
+					return err
+				}
+
+				reports, err := c.GetReportsByPolicyName(ctx, policyName, 1)
+				if err != nil {
+					return fmt.Errorf("error while retrieving reports for failed sync job %s %s", policyName, err.Error())
+				}
+				if !(len(reports.Reports) > 0 && len(reports.Reports[0].Errors) > 0 &&
+					strings.Contains(reports.Reports[0].Errors[0], retryableReportError)) {
+					return fmt.Errorf("found no retryable error in reports for failed sync job %s", policyName)
+				}
+
+				log.Info(ctx, "Sync job failed with error: %s. %v of %v - retrying in %v...",
+					reports.Reports[0].Errors[0], i+1, maxRetries, retryInterval)
+				time.Sleep(retryInterval)
+
+				// Resolve policy with error before retrying
+				err = c.ResolvePolicy(ctx, policyName)
+				if err != nil && !strings.Contains(err.Error(), resolveErrorToIgnore) {
+					return err
+				}
+			} else { // not a retryable error
+				return err
+			}
 		}
+
 		time.Sleep(3 * time.Second)
 		err = c.WaitForNoActiveJobs(ctx, policyName)
 		if err != nil {

--- a/replication.go
+++ b/replication.go
@@ -31,7 +31,7 @@ const defaultPoll = 5 * time.Second
 const defaultTimeout = 10 * time.Minute // set high timeout, we expect to be canceled via context before
 
 const retryInterval = 15 * time.Second
-const maxRetries = 40 // with 15 sec, it is 4 retries per min. For 10 minutes, it is 40 retries
+const maxRetries = 20 // with 15 sec, it is 4 retries per min. For 5 minutes, it is 20 retries
 const retryablePolicyError = "is in an error state. Please resolve it and retry"
 const retryableReportError = "A new quota domain that has not finished QuotaScan has been found"
 const resolveErrorToIgnore = "The policy was not conflicted, so no change was made"
@@ -359,7 +359,7 @@ func (c *Client) SyncPolicy(ctx context.Context, policyName string) error {
 		}
 	}
 	if isRunning {
-		log.Info(ctx, "found active jobs -SL-, waiting for completion")
+		log.Info(ctx, "found active jobs, waiting for completion")
 		err = c.WaitForNoActiveJobs(ctx, policyName)
 		if err != nil {
 			return err

--- a/replication_test.go
+++ b/replication_test.go
@@ -1,7 +1,7 @@
 package goisilon_test
 
 /*
-Copyright (c) 2021-2022 Dell Inc, or its subsidiaries.
+Copyright (c) 2021-2023 Dell Inc, or its subsidiaries.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -45,7 +45,7 @@ func (suite *ReplicationTestSuite) SetupSuite() {
 		"",
 		"dangerous",
 		"/ifs/data/test-goisilon",
-		"0777", 0)
+		"0777", false, 0)
 	if err != nil {
 		panic(err)
 	}
@@ -61,7 +61,7 @@ func (suite *ReplicationTestSuite) SetupSuite() {
 		"",
 		"dangerous",
 		"/ifs/data/test-goisilon",
-		"0777", 0)
+		"0777", false, 0)
 	if err != nil {
 		panic(err)
 	}


### PR DESCRIPTION
# PR Submission checklist

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
| https://github.com/dell/csm/issues/753 |

# Common PR Checklist:

- [x] Have you made sure that the code compiles?
- [x] Have you commented your code, particularly in hard-to-understand areas
- [x] Did you run tests in a real Kubernetes cluster?
- [x] Have you maintained backward compatibility

## Description of your changes:

- Fix query quota call by path. Previous code wouldn't have worked if the PowerScale cluster has more than 1000 quotas.
- Added a workaround fix for SyncIQ job where it could fail with QuotaScan job requirement to be run on target cluster when quota is set on target directories.

Replication tests passed. Please refer to https://github.com/dell/csi-powerscale/pull/182 for test details.

Unit tests are failing. They do fail even on the _main_ branch. UT output attached below. I have asked @nitesh3108 to take a look.
[UT-gopowerscale.txt](https://github.com/dell/gopowerscale/files/11203868/UT-gopowerscale.txt)