### PR TITLE
Implement v4 NFS export and v12 SMB share API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,6 @@
 
 # For VS.Code users
 .vscode/
+
+# For .idea users
+.idea

--- a/api/api_ordered_values_test.go
+++ b/api/api_ordered_values_test.go
@@ -220,3 +220,28 @@ func TestParseQuery(t *testing.T) {
 	tf("name=Andrew%20Kutz&active&alias=akutz")
 	tf("name=Andrew+Kutz&active&alias=akutz")
 }
+
+func TestStructToOrderedValues(t *testing.T) {
+	type TestStruct struct {
+		TestString *string `json:"test_string,omitempty"`
+		TestInt    *int    `json:"test_int,omitempty"`
+		TestBool   *bool   `json:"test_bool,omitempty"`
+		IgnoredField string
+	}
+	testString := "A"
+	testInt := 32
+	testBool := false
+	params := TestStruct{
+		TestString: &testString, TestInt: &testInt, TestBool: &testBool,
+	}
+	var expected OrderedValues
+	expected = [][][]byte{
+		{[]byte("test_string"), []byte("A")},
+		{[]byte("test_int"), []byte("32")},
+		{[]byte("test_bool"), []byte("false")},
+	}
+	actual := StructToOrderedValues(params)
+	if !assert.Equal(t, actual, expected) {
+		t.Errorf("StructToOrderedValue(%v) = %v; want %v", params, actual, expected)
+	}
+}

--- a/api/v12/api_v12_smb_shares.go
+++ b/api/v12/api_v12_smb_shares.go
@@ -1,0 +1,156 @@
+/*
+Copyright (c) 2023 Dell Inc, or its subsidiaries.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package v12
+
+import (
+	"context"
+	"github.com/dell/goisilon/api"
+	"github.com/dell/goisilon/openapi"
+)
+
+const sharesPath = "/platform/12/protocols/smb/shares"
+
+// ListV12SmbSharesParams contains smb shares params
+type ListV12SmbSharesParams struct {
+	Sort         *string `json:"sort,omitempty"`
+	Zone         *string `json:"zone,omitempty"`
+	Resume       *string `json:"resume,omitempty"`
+	ResolveNames *bool   `json:"resolve_names,omitempty"`
+	Limit        *int32  `json:"limit,omitempty"`
+	Offset       *int32  `json:"offset,omitempty"`
+	Scope        *string `json:"scope,omitempty"`
+	Dir          *string `json:"dir,omitempty"`
+}
+
+// ListSmbShares GETs all smb shares.
+func ListSmbShares(
+	ctx context.Context,
+	params ListV12SmbSharesParams,
+	client api.Client) (*openapi.V12SmbShares, error) {
+
+	var resp openapi.V12SmbShares
+	if err := client.Get(
+		ctx,
+		sharesPath,
+		"",
+		api.StructToOrderedValues(params),
+		nil,
+		&resp); err != nil {
+
+		return nil, err
+	}
+
+	return &resp, nil
+}
+
+// GetV12SmbShareParams contains smb share params
+type GetV12SmbShareParams struct {
+	V12SmbShareId string
+	Scope         *string `json:"scope,omitempty"`
+	ResolveNames  *bool   `json:"resolve_names,omitempty"`
+	Zone          *string `json:"zone,omitempty"`
+}
+
+// GetSmbShare GET smb share.
+func GetSmbShare(
+	ctx context.Context,
+	params GetV12SmbShareParams,
+	client api.Client) (*openapi.V12SmbSharesExtended, error) {
+
+	var resp openapi.V12SmbSharesExtended
+	if err := client.Get(
+		ctx,
+		sharesPath,
+		params.V12SmbShareId,
+		api.StructToOrderedValues(params),
+		nil,
+		&resp); err != nil {
+
+		return nil, err
+	}
+
+	return &resp, nil
+}
+
+// CreateV12SmbShareRequest contains request body
+type CreateV12SmbShareRequest struct {
+	V12SmbShare *openapi.V12SmbShare
+	Zone        *string `json:"zone,omitempty"`
+}
+
+// CreateSmbShare POST smb share.
+func CreateSmbShare(
+	ctx context.Context,
+	r CreateV12SmbShareRequest,
+	client api.Client) (*openapi.Createv12SmbShareResponse, error) {
+
+	var resp openapi.Createv12SmbShareResponse
+	if err := client.Post(
+		ctx,
+		sharesPath,
+		"",
+		nil,
+		nil, r.V12SmbShare,
+		&resp); err != nil {
+
+		return nil, err
+	}
+
+	return &resp, nil
+}
+
+// UpdateV12SmbShareRequest contains request body
+type UpdateV12SmbShareRequest struct {
+	V12SmbShareId string
+	V12SmbShare   *openapi.V12SmbShareExtendedExtended
+	Zone          *string `json:"zone,omitempty"`
+}
+
+// UpdateSmbShare UPDATE smb share.
+func UpdateSmbShare(
+	ctx context.Context,
+	r UpdateV12SmbShareRequest,
+	client api.Client) error {
+	err := client.Put(
+		ctx,
+		sharesPath,
+		r.V12SmbShareId,
+		api.StructToOrderedValues(r),
+		nil, r.V12SmbShare,
+		nil)
+
+	return err
+}
+
+// DeleteV12SmbShareRequest contains request params
+type DeleteV12SmbShareRequest struct {
+	V12SmbShareId string
+	Zone          *string `json:"zone,omitempty"`
+}
+
+// DeleteSmbShare Delete one export.
+func DeleteSmbShare(
+	ctx context.Context, r DeleteV12SmbShareRequest,
+	client api.Client) error {
+	err := client.Delete(
+		ctx,
+		sharesPath,
+		r.V12SmbShareId,
+		api.StructToOrderedValues(r),
+		nil, nil)
+
+	return err
+}

--- a/api/v4/api_v4_nfs_exports.go
+++ b/api/v4/api_v4_nfs_exports.go
@@ -1,0 +1,158 @@
+/*
+Copyright (c) 2023 Dell Inc, or its subsidiaries.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package v4
+
+import (
+	"context"
+	"github.com/dell/goisilon/api"
+	"github.com/dell/goisilon/openapi"
+)
+
+const exportsPath = "/platform/4/protocols/nfs/exports"
+
+type ListV4NfsExportsParams struct {
+	Sort   *string `json:"sort,omitempty"`
+	Zone   *string `json:"zone,omitempty"`
+	Resume *string `json:"resume,omitempty"`
+	Scope  *string `json:"scope,omitempty"`
+	Limit  *int32  `json:"limit,omitempty"`
+	Offset *int32  `json:"offset,omitempty"`
+	Path   *string `json:"path,omitempty"`
+	Check  *bool   `json:"check,omitempty"`
+	Dir    *string `json:"dir,omitempty"`
+}
+
+// ListNfsExports GETs all exports.
+func ListNfsExports(
+	ctx context.Context,
+	params ListV4NfsExportsParams,
+	client api.Client) (*openapi.V2NfsExports, error) {
+
+	var resp openapi.V2NfsExports
+	if err := client.Get(
+		ctx,
+		exportsPath,
+		"",
+		api.StructToOrderedValues(params),
+		nil,
+		&resp); err != nil {
+
+		return nil, err
+	}
+
+	return &resp, nil
+}
+
+type GetV2NfsExportRequest struct {
+	V2NfsExportId string
+	Scope         *string `json:"scope,omitempty"`
+	Zone          *string `json:"zone,omitempty"`
+}
+
+// GetNfsExport GET export.
+func GetNfsExport(
+	ctx context.Context,
+	params GetV2NfsExportRequest,
+	client api.Client) (*openapi.V2NfsExportsExtended, error) {
+
+	var resp openapi.V2NfsExportsExtended
+	if err := client.Get(
+		ctx,
+		exportsPath,
+		params.V2NfsExportId,
+		api.StructToOrderedValues(params),
+		nil,
+		&resp); err != nil {
+
+		return nil, err
+	}
+
+	return &resp, nil
+}
+
+type CreateV4NfsExportRequest struct {
+	V4NfsExport             *openapi.V2NfsExport
+	Force                   *bool   `json:"force,omitempty"`
+	IgnoreUnresolvableHosts *bool   `json:"ignore_unresolvable_hosts,omitempty"`
+	Zone                    *string `json:"zone,omitempty"`
+	IgnoreConflicts         *bool   `json:"ignore_conflicts,omitempty"`
+	IgnoreBadPaths          *bool   `json:"ignore_bad_paths,omitempty"`
+	IgnoreBadAuth           *bool   `json:"ignore_bad_auth,omitempty"`
+}
+
+// CreateNfsExport Create one export.
+func CreateNfsExport(
+	ctx context.Context, r CreateV4NfsExportRequest,
+	client api.Client) (*openapi.Createv3EventEventResponse, error) {
+	var resp openapi.Createv3EventEventResponse
+	if err := client.Post(
+		ctx,
+		exportsPath,
+		"",
+		api.StructToOrderedValues(r),
+		nil, r.V4NfsExport,
+		&resp); err != nil {
+
+		return nil, err
+	}
+
+	return &resp, nil
+}
+
+type UpdateV4NfsExportRequest struct {
+	V2NfsExportId           string
+	V2NfsExport             *openapi.V2NfsExportExtendedExtended
+	Force                   *bool   `json:"force,omitempty"`
+	IgnoreUnresolvableHosts *bool   `json:"ignore_unresolvable_hosts,omitempty"`
+	Zone                    *string `json:"zone,omitempty"`
+	IgnoreConflicts         *bool   `json:"ignore_conflicts,omitempty"`
+	IgnoreBadPaths          *bool   `json:"ignore_bad_paths,omitempty"`
+	IgnoreBadAuth           *bool   `json:"ignore_bad_auth,omitempty"`
+}
+
+// UpdateNfsExport Update one export.
+func UpdateNfsExport(
+	ctx context.Context, r UpdateV4NfsExportRequest,
+	client api.Client) error {
+	err := client.Put(
+		ctx,
+		exportsPath,
+		r.V2NfsExportId,
+		api.StructToOrderedValues(r),
+		nil, r.V2NfsExport,
+		nil)
+
+	return err
+}
+
+type DeleteV4NfsExportRequest struct {
+	V2NfsExportId string
+	Zone          *string `json:"zone,omitempty"`
+}
+
+// DeleteNfsExport Delete one export.
+func DeleteNfsExport(
+	ctx context.Context, r DeleteV4NfsExportRequest,
+	client api.Client) error {
+	err := client.Delete(
+		ctx,
+		exportsPath,
+		r.V2NfsExportId,
+		api.StructToOrderedValues(r),
+		nil, nil)
+
+	return err
+}

--- a/exports.go
+++ b/exports.go
@@ -18,6 +18,8 @@ package goisilon
 import (
 	"context"
 	"errors"
+	apiv4 "github.com/dell/goisilon/api/v4"
+	"github.com/dell/goisilon/openapi"
 
 	api "github.com/dell/goisilon/api"
 	"github.com/dell/goisilon/api/common/utils"
@@ -1153,4 +1155,48 @@ func (c *Client) GetExportWithPathAndZone(
 // GetExportByIDWithZone gets the export by export id and access zone
 func (c *Client) GetExportByIDWithZone(ctx context.Context, id int, zone string) (Export, error) {
 	return apiv2.GetExportByIDWithZone(ctx, c.API, id, zone)
+}
+
+// ListAllExportsWithStructParams lists all the exports with parameters
+func (c *Client) ListAllExportsWithStructParams(ctx context.Context, params apiv4.ListV4NfsExportsParams) ([]openapi.V2NfsExportExtended, error) {
+	var result []openapi.V2NfsExportExtended
+	exports, err := apiv4.ListNfsExports(ctx, params, c.API)
+	result = exports.Exports
+	if err != nil {
+		return nil, err
+	}
+	for exports.Resume != nil {
+		resumeParam := apiv4.ListV4NfsExportsParams{Resume: exports.Resume}
+		exports, err = apiv4.ListNfsExports(ctx, resumeParam, c.API)
+		if err != nil {
+			return nil, err
+		}
+		result = append(result, exports.Exports...)
+	}
+	return result, nil
+}
+
+// ListExportsWithStructParams lists all the exports with parameters
+func (c *Client) ListExportsWithStructParams(ctx context.Context, params apiv4.ListV4NfsExportsParams) (*openapi.V2NfsExports, error) {
+	return apiv4.ListNfsExports(ctx, params, c.API)
+}
+
+// GetExportWithStructParams list specific export with parameters
+func (c *Client) GetExportWithStructParams(ctx context.Context, params apiv4.GetV2NfsExportRequest) (*openapi.V2NfsExportsExtended, error) {
+	return apiv4.GetNfsExport(ctx, params, c.API)
+}
+
+// CreateExportWithStructParams create export with parameters
+func (c *Client) CreateExportWithStructParams(ctx context.Context, params apiv4.CreateV4NfsExportRequest) (*openapi.Createv3EventEventResponse, error) {
+	return apiv4.CreateNfsExport(ctx, params, c.API)
+}
+
+// DeleteExportWithStructParams delete export with parameters
+func (c *Client) DeleteExportWithStructParams(ctx context.Context, params apiv4.DeleteV4NfsExportRequest) error {
+	return apiv4.DeleteNfsExport(ctx, params, c.API)
+}
+
+// UpdateExportWithStructParams update export with parameters
+func (c *Client) UpdateExportWithStructParams(ctx context.Context, params apiv4.UpdateV4NfsExportRequest) error {
+	return apiv4.UpdateNfsExport(ctx, params, c.API)
 }

--- a/openapi/model_createv12_smb_share_response.go
+++ b/openapi/model_createv12_smb_share_response.go
@@ -1,0 +1,23 @@
+/*
+	Copyright (c) 2023 Dell Inc, or its subsidiaries.
+
+	Licensed under the Apache License, Version 2.0 (the "License");
+	you may not use this file except in compliance with the License.
+	You may obtain a copy of the License at
+
+		http://www.apache.org/licenses/LICENSE-2.0
+
+	Unless required by applicable law or agreed to in writing, software
+	distributed under the License is distributed on an "AS IS" BASIS,
+	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+	See the License for the specific language governing permissions and
+	limitations under the License.
+*/
+
+package openapi
+
+// Createv12SmbShareResponse An array of ids to refer SMB shares.
+type Createv12SmbShareResponse struct {
+	// ID of created item that can be used to refer to item in the collection-item resource path.
+	Id string `json:"id"`
+}

--- a/openapi/model_createv3_event_event_response.go
+++ b/openapi/model_createv3_event_event_response.go
@@ -1,0 +1,23 @@
+/*
+	Copyright (c) 2023 Dell Inc, or its subsidiaries.
+
+	Licensed under the Apache License, Version 2.0 (the "License");
+	you may not use this file except in compliance with the License.
+	You may obtain a copy of the License at
+
+		http://www.apache.org/licenses/LICENSE-2.0
+
+	Unless required by applicable law or agreed to in writing, software
+	distributed under the License is distributed on an "AS IS" BASIS,
+	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+	See the License for the specific language governing permissions and
+	limitations under the License.
+*/
+
+package openapi
+
+// Createv3EventEventResponse struct for Createv3EventEventResponse
+type Createv3EventEventResponse struct {
+	// ID of created item that can be used to refer to item in the collection-item resource path.
+	Id int32 `json:"id"`
+}

--- a/openapi/model_error.go
+++ b/openapi/model_error.go
@@ -1,0 +1,23 @@
+/*
+	Copyright (c) 2023 Dell Inc, or its subsidiaries.
+
+	Licensed under the Apache License, Version 2.0 (the "License");
+	you may not use this file except in compliance with the License.
+	You may obtain a copy of the License at
+
+		http://www.apache.org/licenses/LICENSE-2.0
+
+	Unless required by applicable law or agreed to in writing, software
+	distributed under the License is distributed on an "AS IS" BASIS,
+	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+	See the License for the specific language governing permissions and
+	limitations under the License.
+*/
+
+package openapi
+
+// Error struct for Error
+type Error struct {
+	Code int32 `json:"code"`
+	Message string `json:"message"`
+}

--- a/openapi/model_v12_smb_share.go
+++ b/openapi/model_v12_smb_share.go
@@ -1,0 +1,103 @@
+/*
+	Copyright (c) 2023 Dell Inc, or its subsidiaries.
+
+	Licensed under the Apache License, Version 2.0 (the "License");
+	you may not use this file except in compliance with the License.
+	You may obtain a copy of the License at
+
+		http://www.apache.org/licenses/LICENSE-2.0
+
+	Unless required by applicable law or agreed to in writing, software
+	distributed under the License is distributed on an "AS IS" BASIS,
+	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+	See the License for the specific language governing permissions and
+	limitations under the License.
+*/
+
+package openapi
+
+// V12SmbShare struct for V12SmbShare
+type V12SmbShare struct {
+	// Only enumerate files and folders the requesting user has access to.
+	AccessBasedEnumeration *bool `json:"access_based_enumeration,omitempty"`
+	// Access-based enumeration on only the root directory of the share.
+	AccessBasedEnumerationRootOnly *bool `json:"access_based_enumeration_root_only,omitempty"`
+	// Allow deletion of read-only files in the share.
+	AllowDeleteReadonly *bool `json:"allow_delete_readonly,omitempty"`
+	// Allows users to execute files they have read rights for.
+	AllowExecuteAlways *bool `json:"allow_execute_always,omitempty"`
+	// Allow automatic expansion of variables for home directories.
+	AllowVariableExpansion *bool `json:"allow_variable_expansion,omitempty"`
+	// Automatically create home directories.
+	AutoCreateDirectory *bool `json:"auto_create_directory,omitempty"`
+	// Share is visible in net view and the browse list.
+	Browsable *bool `json:"browsable,omitempty"`
+	// Persistent open timeout for the share.
+	CaTimeout *int32 `json:"ca_timeout,omitempty"`
+	// Specify the level of write-integrity on continuously available shares.
+	CaWriteIntegrity *string `json:"ca_write_integrity,omitempty"`
+	// Level of change notification alerts on the share.
+	ChangeNotify *string `json:"change_notify,omitempty"`
+	// Specify if persistent opens are allowed on the share.
+	ContinuouslyAvailable *bool `json:"continuously_available,omitempty"`
+	// Create path if does not exist.
+	CreatePath *bool `json:"create_path,omitempty"`
+	// Create permissions for new files and directories in share.
+	CreatePermissions *string `json:"create_permissions,omitempty"`
+	// Client-side caching policy for the shares.
+	CscPolicy *string `json:"csc_policy,omitempty"`
+	// Description for this SMB share.
+	Description *string `json:"description,omitempty"`
+	// Directory create mask bits.
+	DirectoryCreateMask *int32 `json:"directory_create_mask,omitempty"`
+	// Directory create mode bits.
+	DirectoryCreateMode *int32 `json:"directory_create_mode,omitempty"`
+	// File create mask bits.
+	FileCreateMask *int32 `json:"file_create_mask,omitempty"`
+	// File create mode bits.
+	FileCreateMode *int32 `json:"file_create_mode,omitempty"`
+	// Specifies the list of file extensions.
+	FileFilterExtensions []string `json:"file_filter_extensions,omitempty"`
+	// Specifies if filter list is for deny or allow. Default is deny.
+	FileFilterType *string `json:"file_filter_type,omitempty"`
+	// Enables file filtering on this zone.
+	FileFilteringEnabled *bool `json:"file_filtering_enabled,omitempty"`
+	// Hide files and directories that begin with a period '.'.
+	HideDotFiles *bool `json:"hide_dot_files,omitempty"`
+	// An ACL expressing which hosts are allowed access. A deny clause must be the final entry.
+	HostAcl []string `json:"host_acl,omitempty"`
+	// Specify the condition in which user access is done as the guest account.
+	ImpersonateGuest *string `json:"impersonate_guest,omitempty"`
+	// User account to be used as guest account.
+	ImpersonateUser *string `json:"impersonate_user,omitempty"`
+	// Set the inheritable ACL on the share path.
+	InheritablePathAcl *bool `json:"inheritable_path_acl,omitempty"`
+	// Specifies the wchar_t starting point for automatic byte mangling.
+	MangleByteStart *int32 `json:"mangle_byte_start,omitempty"`
+	// Character mangle map.
+	MangleMap []string `json:"mangle_map,omitempty"`
+	// Share name.
+	Name string `json:"name"`
+	// Support NTFS ACLs on files and directories.
+	NtfsAclSupport *bool `json:"ntfs_acl_support,omitempty"`
+	// Support oplocks.
+	Oplocks *bool `json:"oplocks,omitempty"`
+	// Path of share within /ifs.
+	Path string `json:"path"`
+	// Specifies an ordered list of permission modifications.
+	Permissions []V1SmbSharePermission `json:"permissions,omitempty"`
+	// Allow account to run as root.
+	RunAsRoot []V1AuthAccessAccessItemFileGroup `json:"run_as_root,omitempty"`
+	// Enables SMB3 encryption for the share.
+	Smb3EncryptionEnabled *bool `json:"smb3_encryption_enabled,omitempty"`
+	// Enables sparse file.
+	SparseFile *bool `json:"sparse_file,omitempty"`
+	// Specifies if persistent opens would do strict lockout on the share.
+	StrictCaLockout *bool `json:"strict_ca_lockout,omitempty"`
+	// Handle SMB flush operations.
+	StrictFlush *bool `json:"strict_flush,omitempty"`
+	// Specifies whether byte range locks contend against SMB I/O.
+	StrictLocking *bool `json:"strict_locking,omitempty"`
+	// Name of the access zone to which to move this SMB share.
+	Zone *string `json:"zone,omitempty"`
+}

--- a/openapi/model_v12_smb_share_extended.go
+++ b/openapi/model_v12_smb_share_extended.go
@@ -1,0 +1,104 @@
+/*
+	Copyright (c) 2023 Dell Inc, or its subsidiaries.
+
+	Licensed under the Apache License, Version 2.0 (the "License");
+	you may not use this file except in compliance with the License.
+	You may obtain a copy of the License at
+
+		http://www.apache.org/licenses/LICENSE-2.0
+
+	Unless required by applicable law or agreed to in writing, software
+	distributed under the License is distributed on an "AS IS" BASIS,
+	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+	See the License for the specific language governing permissions and
+	limitations under the License.
+*/
+
+package openapi
+
+// V12SmbShareExtended struct for V12SmbShareExtended
+type V12SmbShareExtended struct {
+	// Only enumerate files and folders the requesting user has access to.
+	AccessBasedEnumeration *bool `json:"access_based_enumeration,omitempty"`
+	// Access-based enumeration on only the root directory of the share.
+	AccessBasedEnumerationRootOnly *bool `json:"access_based_enumeration_root_only,omitempty"`
+	// Allow deletion of read-only files in the share.
+	AllowDeleteReadonly *bool `json:"allow_delete_readonly,omitempty"`
+	// Allows users to execute files they have read rights for.
+	AllowExecuteAlways *bool `json:"allow_execute_always,omitempty"`
+	// Allow automatic expansion of variables for home directories.
+	AllowVariableExpansion *bool `json:"allow_variable_expansion,omitempty"`
+	// Automatically create home directories.
+	AutoCreateDirectory *bool `json:"auto_create_directory,omitempty"`
+	// Share is visible in net view and the browse list.
+	Browsable *bool `json:"browsable,omitempty"`
+	// Persistent open timeout for the share.
+	CaTimeout *int32 `json:"ca_timeout,omitempty"`
+	// Specify the level of write-integrity on continuously available shares.
+	CaWriteIntegrity *string `json:"ca_write_integrity,omitempty"`
+	// Level of change notification alerts on the share.
+	ChangeNotify *string `json:"change_notify,omitempty"`
+	// Specify if persistent opens are allowed on the share.
+	ContinuouslyAvailable *bool `json:"continuously_available,omitempty"`
+	// Create permissions for new files and directories in share.
+	CreatePermissions *string `json:"create_permissions,omitempty"`
+	// Client-side caching policy for the shares.
+	CscPolicy *string `json:"csc_policy,omitempty"`
+	// Description for this SMB share.
+	Description *string `json:"description,omitempty"`
+	// Directory create mask bits.
+	DirectoryCreateMask *int32 `json:"directory_create_mask,omitempty"`
+	// Directory create mode bits.
+	DirectoryCreateMode *int32 `json:"directory_create_mode,omitempty"`
+	// File create mask bits.
+	FileCreateMask *int32 `json:"file_create_mask,omitempty"`
+	// File create mode bits.
+	FileCreateMode *int32 `json:"file_create_mode,omitempty"`
+	// Specifies the list of file extensions.
+	FileFilterExtensions []string `json:"file_filter_extensions,omitempty"`
+	// Specifies if filter list is for deny or allow. Default is deny.
+	FileFilterType *string `json:"file_filter_type,omitempty"`
+	// Enables file filtering on this zone.
+	FileFilteringEnabled *bool `json:"file_filtering_enabled,omitempty"`
+	// Hide files and directories that begin with a period '.'.
+	HideDotFiles *bool `json:"hide_dot_files,omitempty"`
+	// An ACL expressing which hosts are allowed access. A deny clause must be the final entry.
+	HostAcl []string `json:"host_acl,omitempty"`
+	// Share ID.
+	Id string `json:"id"`
+	// Specify the condition in which user access is done as the guest account.
+	ImpersonateGuest *string `json:"impersonate_guest,omitempty"`
+	// User account to be used as guest account.
+	ImpersonateUser *string `json:"impersonate_user,omitempty"`
+	// Set the inheritable ACL on the share path.
+	InheritablePathAcl *bool `json:"inheritable_path_acl,omitempty"`
+	// Specifies the wchar_t starting point for automatic byte mangling.
+	MangleByteStart *int32 `json:"mangle_byte_start,omitempty"`
+	// Character mangle map.
+	MangleMap []string `json:"mangle_map,omitempty"`
+	// Share name.
+	Name string `json:"name"`
+	// Support NTFS ACLs on files and directories.
+	NtfsAclSupport *bool `json:"ntfs_acl_support,omitempty"`
+	// Support oplocks.
+	Oplocks *bool `json:"oplocks,omitempty"`
+	// Path of share within /ifs.
+	Path string `json:"path"`
+	// Specifies an ordered list of permission modifications.
+	Permissions []V1SmbSharePermission `json:"permissions,omitempty"`
+	// Allow account to run as root.
+	RunAsRoot []V1AuthAccessAccessItemFileGroup `json:"run_as_root,omitempty"`
+	// Enables SMB3 encryption for the share.
+	Smb3EncryptionEnabled *bool `json:"smb3_encryption_enabled,omitempty"`
+	// Enables sparse file.
+	SparseFile *bool `json:"sparse_file,omitempty"`
+	// Specifies if persistent opens would do strict lockout on the share.
+	StrictCaLockout *bool `json:"strict_ca_lockout,omitempty"`
+	// Handle SMB flush operations.
+	StrictFlush *bool `json:"strict_flush,omitempty"`
+	// Specifies whether byte range locks contend against SMB I/O.
+	StrictLocking *bool `json:"strict_locking,omitempty"`
+	// Numeric ID of the access zone which contains this SMB share
+	Zid int32 `json:"zid"`
+}
+

--- a/openapi/model_v12_smb_share_extended_extended.go
+++ b/openapi/model_v12_smb_share_extended_extended.go
@@ -1,0 +1,99 @@
+/*
+	Copyright (c) 2023 Dell Inc, or its subsidiaries.
+
+	Licensed under the Apache License, Version 2.0 (the "License");
+	you may not use this file except in compliance with the License.
+	You may obtain a copy of the License at
+
+		http://www.apache.org/licenses/LICENSE-2.0
+
+	Unless required by applicable law or agreed to in writing, software
+	distributed under the License is distributed on an "AS IS" BASIS,
+	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+	See the License for the specific language governing permissions and
+	limitations under the License.
+*/
+
+package openapi
+
+// V12SmbShareExtendedExtended struct for V12SmbShareExtendedExtended
+type V12SmbShareExtendedExtended struct {
+	// Only enumerate files and folders the requesting user has access to.
+	AccessBasedEnumeration *bool `json:"access_based_enumeration,omitempty"`
+	// Access-based enumeration on only the root directory of the share.
+	AccessBasedEnumerationRootOnly *bool `json:"access_based_enumeration_root_only,omitempty"`
+	// Allow deletion of read-only files in the share.
+	AllowDeleteReadonly *bool `json:"allow_delete_readonly,omitempty"`
+	// Allows users to execute files they have read rights for.
+	AllowExecuteAlways *bool `json:"allow_execute_always,omitempty"`
+	// Allow automatic expansion of variables for home directories.
+	AllowVariableExpansion *bool `json:"allow_variable_expansion,omitempty"`
+	// Automatically create home directories.
+	AutoCreateDirectory *bool `json:"auto_create_directory,omitempty"`
+	// Share is visible in net view and the browse list.
+	Browsable *bool `json:"browsable,omitempty"`
+	// Persistent open timeout for the share.
+	CaTimeout *int32 `json:"ca_timeout,omitempty"`
+	// Specify the level of write-integrity on continuously available shares.
+	CaWriteIntegrity *string `json:"ca_write_integrity,omitempty"`
+	// Level of change notification alerts on the share.
+	ChangeNotify *string `json:"change_notify,omitempty"`
+	// Create permissions for new files and directories in share.
+	CreatePermissions *string `json:"create_permissions,omitempty"`
+	// Client-side caching policy for the shares.
+	CscPolicy *string `json:"csc_policy,omitempty"`
+	// Description for this SMB share.
+	Description *string `json:"description,omitempty"`
+	// Directory create mask bits.
+	DirectoryCreateMask *int32 `json:"directory_create_mask,omitempty"`
+	// Directory create mode bits.
+	DirectoryCreateMode *int32 `json:"directory_create_mode,omitempty"`
+	// File create mask bits.
+	FileCreateMask *int32 `json:"file_create_mask,omitempty"`
+	// File create mode bits.
+	FileCreateMode *int32 `json:"file_create_mode,omitempty"`
+	// Specifies the list of file extensions.
+	FileFilterExtensions []string `json:"file_filter_extensions,omitempty"`
+	// Specifies if filter list is for deny or allow. Default is deny.
+	FileFilterType *string `json:"file_filter_type,omitempty"`
+	// Enables file filtering on this zone.
+	FileFilteringEnabled *bool `json:"file_filtering_enabled,omitempty"`
+	// Hide files and directories that begin with a period '.'.
+	HideDotFiles *bool `json:"hide_dot_files,omitempty"`
+	// An ACL expressing which hosts are allowed access. A deny clause must be the final entry.
+	HostAcl []string `json:"host_acl,omitempty"`
+	// Specify the condition in which user access is done as the guest account.
+	ImpersonateGuest *string `json:"impersonate_guest,omitempty"`
+	// User account to be used as guest account.
+	ImpersonateUser *string `json:"impersonate_user,omitempty"`
+	// Set the inheritable ACL on the share path.
+	InheritablePathAcl *bool `json:"inheritable_path_acl,omitempty"`
+	// Specifies the wchar_t starting point for automatic byte mangling.
+	MangleByteStart *int32 `json:"mangle_byte_start,omitempty"`
+	// Character mangle map.
+	MangleMap []string `json:"mangle_map,omitempty"`
+	// Share name.
+	Name *string `json:"name,omitempty"`
+	// Support NTFS ACLs on files and directories.
+	NtfsAclSupport *bool `json:"ntfs_acl_support,omitempty"`
+	// Support oplocks.
+	Oplocks *bool `json:"oplocks,omitempty"`
+	// Path of share within /ifs.
+	Path *string `json:"path,omitempty"`
+	// Specifies an ordered list of permission modifications.
+	Permissions []V1SmbSharePermission `json:"permissions,omitempty"`
+	// Allow account to run as root.
+	RunAsRoot []V1AuthAccessAccessItemFileGroup `json:"run_as_root,omitempty"`
+	// Enables SMB3 encryption for the share.
+	Smb3EncryptionEnabled *bool `json:"smb3_encryption_enabled,omitempty"`
+	// Enables sparse file.
+	SparseFile *bool `json:"sparse_file,omitempty"`
+	// Specifies if persistent opens would do strict lockout on the share.
+	StrictCaLockout *bool `json:"strict_ca_lockout,omitempty"`
+	// Handle SMB flush operations.
+	StrictFlush *bool `json:"strict_flush,omitempty"`
+	// Specifies whether byte range locks contend against SMB I/O.
+	StrictLocking *bool `json:"strict_locking,omitempty"`
+	// Name of the access zone to which to move this SMB share.
+	Zone *string `json:"zone,omitempty"`
+}

--- a/openapi/model_v12_smb_shares.go
+++ b/openapi/model_v12_smb_shares.go
@@ -1,0 +1,28 @@
+/*
+	Copyright (c) 2023 Dell Inc, or its subsidiaries.
+
+	Licensed under the Apache License, Version 2.0 (the "License");
+	you may not use this file except in compliance with the License.
+	You may obtain a copy of the License at
+
+		http://www.apache.org/licenses/LICENSE-2.0
+
+	Unless required by applicable law or agreed to in writing, software
+	distributed under the License is distributed on an "AS IS" BASIS,
+	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+	See the License for the specific language governing permissions and
+	limitations under the License.
+*/
+
+package openapi
+
+// V12SmbShares struct for V12SmbShares
+type V12SmbShares struct {
+	// An identifier for a set of shares.
+	Digest *string `json:"digest,omitempty"`
+	// Provide this token as the 'resume' query argument to continue listing results.
+	Resume *string `json:"resume,omitempty"`
+	Shares []V12SmbShareExtended `json:"shares"`
+	// Total number of items available.
+	Total *int32 `json:"total,omitempty"`
+}

--- a/openapi/model_v12_smb_shares_extended.go
+++ b/openapi/model_v12_smb_shares_extended.go
@@ -1,0 +1,22 @@
+/*
+	Copyright (c) 2023 Dell Inc, or its subsidiaries.
+
+	Licensed under the Apache License, Version 2.0 (the "License");
+	you may not use this file except in compliance with the License.
+	You may obtain a copy of the License at
+
+		http://www.apache.org/licenses/LICENSE-2.0
+
+	Unless required by applicable law or agreed to in writing, software
+	distributed under the License is distributed on an "AS IS" BASIS,
+	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+	See the License for the specific language governing permissions and
+	limitations under the License.
+*/
+
+package openapi
+
+// V12SmbSharesExtended struct for V12SmbSharesExtended
+type V12SmbSharesExtended struct {
+	Shares []V12SmbShareExtended `json:"shares"`
+}

--- a/openapi/model_v1_auth_access_access_item_file_group.go
+++ b/openapi/model_v1_auth_access_access_item_file_group.go
@@ -1,0 +1,27 @@
+/*
+	Copyright (c) 2023 Dell Inc, or its subsidiaries.
+
+	Licensed under the Apache License, Version 2.0 (the "License");
+	you may not use this file except in compliance with the License.
+	You may obtain a copy of the License at
+
+		http://www.apache.org/licenses/LICENSE-2.0
+
+	Unless required by applicable law or agreed to in writing, software
+	distributed under the License is distributed on an "AS IS" BASIS,
+	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+	See the License for the specific language governing permissions and
+	limitations under the License.
+*/
+
+package openapi
+
+// V1AuthAccessAccessItemFileGroup Specifies the persona of the file group.
+type V1AuthAccessAccessItemFileGroup struct {
+	// Specifies the serialized form of a persona, which can be 'UID:0', 'USER:name', 'GID:0', 'GROUP:wheel', or 'SID:S-1-1'.
+	Id *string `json:"id,omitempty"`
+	// Specifies the persona name, which must be combined with a type.
+	Name *string `json:"name,omitempty"`
+	// Specifies the type of persona, which must be combined with a name.
+	Type *string `json:"type,omitempty"`
+}

--- a/openapi/model_v1_smb_share_permission.go
+++ b/openapi/model_v1_smb_share_permission.go
@@ -1,0 +1,26 @@
+/*
+	Copyright (c) 2023 Dell Inc, or its subsidiaries.
+
+	Licensed under the Apache License, Version 2.0 (the "License");
+	you may not use this file except in compliance with the License.
+	You may obtain a copy of the License at
+
+		http://www.apache.org/licenses/LICENSE-2.0
+
+	Unless required by applicable law or agreed to in writing, software
+	distributed under the License is distributed on an "AS IS" BASIS,
+	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+	See the License for the specific language governing permissions and
+	limitations under the License.
+*/
+
+package openapi
+
+// V1SmbSharePermission Specifies properties for an Access Control Entry.
+type V1SmbSharePermission struct {
+	// Specifies the file system rights that are allowed or denied.
+	Permission string `json:"permission"`
+	// Determines whether the permission is allowed or denied.
+	PermissionType string `json:"permission_type"`
+	Trustee V1AuthAccessAccessItemFileGroup `json:"trustee"`
+}

--- a/openapi/model_v2_nfs_export.go
+++ b/openapi/model_v2_nfs_export.go
@@ -1,0 +1,113 @@
+/*
+	Copyright (c) 2023 Dell Inc, or its subsidiaries.
+
+	Licensed under the Apache License, Version 2.0 (the "License");
+	you may not use this file except in compliance with the License.
+	You may obtain a copy of the License at
+
+		http://www.apache.org/licenses/LICENSE-2.0
+
+	Unless required by applicable law or agreed to in writing, software
+	distributed under the License is distributed on an "AS IS" BASIS,
+	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+	See the License for the specific language governing permissions and
+	limitations under the License.
+*/
+
+package openapi
+
+// V2NfsExport Specifies configuration values for NFS exports.
+type V2NfsExport struct {
+	// True if all directories under the specified paths are mountable.
+	AllDirs *bool `json:"all_dirs,omitempty"`
+	// Specifies the block size returned by the NFS statfs procedure.
+	BlockSize *int32 `json:"block_size,omitempty"`
+	// True if the client can set file times through the NFS set attribute request. This parameter does not affect server behavior, but is included to accommodate legacy client requirements.
+	CanSetTime *bool `json:"can_set_time,omitempty"`
+	// True if the case is ignored for file names. This parameter does not affect server behavior, but is included to accommodate legacy client requirements.
+	CaseInsensitive *bool `json:"case_insensitive,omitempty"`
+	// True if the case is preserved for file names. This parameter does not affect server behavior, but is included to accommodate legacy client requirements.
+	CasePreserving *bool `json:"case_preserving,omitempty"`
+	// True if the superuser can change file ownership. This parameter does not affect server behavior, but is included to accommodate legacy client requirements.
+	ChownRestricted *bool `json:"chown_restricted,omitempty"`
+	// Specifies the clients with root access to the export.
+	Clients []string `json:"clients,omitempty"`
+	// True if NFS  commit  requests execute asynchronously.
+	CommitAsynchronous *bool `json:"commit_asynchronous,omitempty"`
+	// Specifies the user-defined string that is used to identify the export.
+	Description *string `json:"description,omitempty"`
+	// Specifies the preferred size for directory read operations. This value is used to advise the client of optimal settings for the server, but is not enforced.
+	DirectoryTransferSize *int32 `json:"directory_transfer_size,omitempty"`
+	// Specifies the default character set encoding of the clients connecting to the export, unless otherwise specified.
+	Encoding *string `json:"encoding,omitempty"`
+	// Specifies the reported maximum number of links to a file. This parameter does not affect server behavior, but is included to accommodate legacy client requirements.
+	LinkMax *int32 `json:"link_max,omitempty"`
+	MapAll *V2NfsExportMapAll `json:"map_all,omitempty"`
+	MapFailure *V2NfsExportMapAll `json:"map_failure,omitempty"`
+	// True if user mappings query the OneFS user database. When set to false, user mappings only query local authentication.
+	MapFull *bool `json:"map_full,omitempty"`
+	// True if incoming user IDs (UIDs) are mapped to users in the OneFS user database. When set to false, incoming UIDs are applied directly to file operations.
+	MapLookupUid *bool `json:"map_lookup_uid,omitempty"`
+	MapNonRoot *V2NfsExportMapAll `json:"map_non_root,omitempty"`
+	// Determines whether searches for users specified in 'map_all', 'map_root' or 'map_nonroot' are retried if the search fails.
+	MapRetry *bool `json:"map_retry,omitempty"`
+	MapRoot *V2NfsExportMapAll `json:"map_root,omitempty"`
+	// Specifies the maximum file size for any file accessed from the export. This parameter does not affect server behavior, but is included to accommodate legacy client requirements.
+	MaxFileSize *int64 `json:"max_file_size,omitempty"`
+	// Specifies the reported maximum length of a file name. This parameter does not affect server behavior, but is included to accommodate legacy client requirements.
+	NameMaxSize *int32 `json:"name_max_size,omitempty"`
+	// True if long file names result in an error. This parameter does not affect server behavior, but is included to accommodate legacy client requirements.
+	NoTruncate *bool `json:"no_truncate,omitempty"`
+	// Specifies the paths under /ifs that are exported.
+	Paths []string `json:"paths"`
+	// True if the export is set to read-only.
+	ReadOnly *bool `json:"read_only,omitempty"`
+	// Specifies the clients with read-only access to the export.
+	ReadOnlyClients []string `json:"read_only_clients,omitempty"`
+	// Specifies the maximum buffer size that clients should use on NFS read requests. This value is used to advise the client of optimal settings for the server, but is not enforced.
+	ReadTransferMaxSize *int32 `json:"read_transfer_max_size,omitempty"`
+	// Specifies the preferred multiple size for NFS read requests. This value is used to advise the client of optimal settings for the server, but is not enforced.
+	ReadTransferMultiple *int32 `json:"read_transfer_multiple,omitempty"`
+	// Specifies the preferred size for NFS read requests. This value is used to advise the client of optimal settings for the server, but is not enforced.
+	ReadTransferSize *int32 `json:"read_transfer_size,omitempty"`
+	// Specifies the clients with both read and write access to the export, even when the export is set to read-only.
+	ReadWriteClients []string `json:"read_write_clients,omitempty"`
+	// True if 'readdirplus' requests are enabled. Enabling this property might improve network performance and is only available for NFSv3.
+	Readdirplus *bool `json:"readdirplus,omitempty"`
+	// Sets the number of directory entries that are prefetched when a 'readdirplus' request is processed. (Deprecated.)
+	ReaddirplusPrefetch *int32 `json:"readdirplus_prefetch,omitempty"`
+	// Limits the size of file identifiers returned by NFSv3+ to 32-bit values (may require remount).
+	Return32bitFileIds *bool `json:"return_32bit_file_ids,omitempty"`
+	// Clients that have root access to the export.
+	RootClients []string `json:"root_clients,omitempty"`
+	// Specifies the authentication types that are supported for this export.
+	SecurityFlavors []string `json:"security_flavors,omitempty"`
+	// True if set attribute operations execute asynchronously.
+	SetattrAsynchronous *bool `json:"setattr_asynchronous,omitempty"`
+	// Specifies the snapshot for all mounts.
+	Snapshot *string `json:"snapshot,omitempty"`
+	// True if symlinks are supported. This value is used to advise the client of optimal settings for the server, but is not enforced.
+	Symlinks *bool `json:"symlinks,omitempty"`
+	// Specifies the resolution of all time values that are returned to the clients
+	TimeDelta *float32 `json:"time_delta,omitempty"`
+	// Specifies the action to be taken when an NFSv3+ datasync write is requested.
+	WriteDatasyncAction *string `json:"write_datasync_action,omitempty"`
+	// Specifies the stability disposition returned when an NFSv3+ datasync write is processed.
+	WriteDatasyncReply *string `json:"write_datasync_reply,omitempty"`
+	// Specifies the action to be taken when an NFSv3+ filesync write is requested.
+	WriteFilesyncAction *string `json:"write_filesync_action,omitempty"`
+	// Specifies the stability disposition returned when an NFSv3+ filesync write is processed.
+	WriteFilesyncReply *string `json:"write_filesync_reply,omitempty"`
+	// Specifies the maximum buffer size that clients should use on NFS write requests. This value is used to advise the client of optimal settings for the server, but is not enforced.
+	WriteTransferMaxSize *int32 `json:"write_transfer_max_size,omitempty"`
+	// Specifies the preferred multiple size for NFS write requests. This value is used to advise the client of optimal settings for the server, but is not enforced.
+	WriteTransferMultiple *int32 `json:"write_transfer_multiple,omitempty"`
+	// Specifies the preferred multiple size for NFS write requests. This value is used to advise the client of optimal settings for the server, but is not enforced.
+	WriteTransferSize *int32 `json:"write_transfer_size,omitempty"`
+	// Specifies the action to be taken when an NFSv3+ unstable write is requested.
+	WriteUnstableAction *string `json:"write_unstable_action,omitempty"`
+	// Specifies the stability disposition returned when an NFSv3+ unstable write is processed.
+	WriteUnstableReply *string `json:"write_unstable_reply,omitempty"`
+	// Specifies the zone in which the export is valid.
+	Zone *string `json:"zone,omitempty"`
+}

--- a/openapi/model_v2_nfs_export_extended.go
+++ b/openapi/model_v2_nfs_export_extended.go
@@ -1,0 +1,119 @@
+/*
+	Copyright (c) 2023 Dell Inc, or its subsidiaries.
+
+	Licensed under the Apache License, Version 2.0 (the "License");
+	you may not use this file except in compliance with the License.
+	You may obtain a copy of the License at
+
+		http://www.apache.org/licenses/LICENSE-2.0
+
+	Unless required by applicable law or agreed to in writing, software
+	distributed under the License is distributed on an "AS IS" BASIS,
+	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+	See the License for the specific language governing permissions and
+	limitations under the License.
+*/
+
+package openapi
+
+// V2NfsExportExtended Specifies configuration values for NFS exports.
+type V2NfsExportExtended struct {
+	// True if all directories under the specified paths are mountable.
+	AllDirs *bool `json:"all_dirs,omitempty"`
+	// Specifies the block size returned by the NFS statfs procedure.
+	BlockSize *int32 `json:"block_size,omitempty"`
+	// True if the client can set file times through the NFS set attribute request. This parameter does not affect server behavior, but is included to accommodate legacy client requirements.
+	CanSetTime *bool `json:"can_set_time,omitempty"`
+	// True if the case is ignored for file names. This parameter does not affect server behavior, but is included to accommodate legacy client requirements.
+	CaseInsensitive *bool `json:"case_insensitive,omitempty"`
+	// True if the case is preserved for file names. This parameter does not affect server behavior, but is included to accommodate legacy client requirements.
+	CasePreserving *bool `json:"case_preserving,omitempty"`
+	// True if the superuser can change file ownership. This parameter does not affect server behavior, but is included to accommodate legacy client requirements.
+	ChownRestricted *bool `json:"chown_restricted,omitempty"`
+	// Specifies the clients with root access to the export.
+	Clients []string `json:"clients,omitempty"`
+	// True if NFS  commit  requests execute asynchronously.
+	CommitAsynchronous *bool `json:"commit_asynchronous,omitempty"`
+	// Reports the paths that conflict with another export.
+	ConflictingPaths []string `json:"conflicting_paths,omitempty"`
+	// Specifies the user-defined string that is used to identify the export.
+	Description *string `json:"description,omitempty"`
+	// Specifies the preferred size for directory read operations. This value is used to advise the client of optimal settings for the server, but is not enforced.
+	DirectoryTransferSize *int32 `json:"directory_transfer_size,omitempty"`
+	// Specifies the default character set encoding of the clients connecting to the export, unless otherwise specified.
+	Encoding *string `json:"encoding,omitempty"`
+	// Specifies the system-assigned ID for the export. This ID is returned when an export is created through the POST method.
+	Id *int32 `json:"id,omitempty"`
+	// Specifies the reported maximum number of links to a file. This parameter does not affect server behavior, but is included to accommodate legacy client requirements.
+	LinkMax *int32 `json:"link_max,omitempty"`
+	MapAll *V2NfsExportMapAll `json:"map_all,omitempty"`
+	MapFailure *V2NfsExportMapAll `json:"map_failure,omitempty"`
+	// True if user mappings query the OneFS user database. When set to false, user mappings only query local authentication.
+	MapFull *bool `json:"map_full,omitempty"`
+	// True if incoming user IDs (UIDs) are mapped to users in the OneFS user database. When set to false, incoming UIDs are applied directly to file operations.
+	MapLookupUid *bool `json:"map_lookup_uid,omitempty"`
+	MapNonRoot *V2NfsExportMapAll `json:"map_non_root,omitempty"`
+	// Determines whether searches for users specified in 'map_all', 'map_root' or 'map_nonroot' are retried if the search fails.
+	MapRetry *bool `json:"map_retry,omitempty"`
+	MapRoot *V2NfsExportMapAll `json:"map_root,omitempty"`
+	// Specifies the maximum file size for any file accessed from the export. This parameter does not affect server behavior, but is included to accommodate legacy client requirements.
+	MaxFileSize *int64 `json:"max_file_size,omitempty"`
+	// Specifies the reported maximum length of a file name. This parameter does not affect server behavior, but is included to accommodate legacy client requirements.
+	NameMaxSize *int32 `json:"name_max_size,omitempty"`
+	// True if long file names result in an error. This parameter does not affect server behavior, but is included to accommodate legacy client requirements.
+	NoTruncate *bool `json:"no_truncate,omitempty"`
+	// Specifies the paths under /ifs that are exported.
+	Paths []string `json:"paths,omitempty"`
+	// True if the export is set to read-only.
+	ReadOnly *bool `json:"read_only,omitempty"`
+	// Specifies the clients with read-only access to the export.
+	ReadOnlyClients []string `json:"read_only_clients,omitempty"`
+	// Specifies the maximum buffer size that clients should use on NFS read requests. This value is used to advise the client of optimal settings for the server, but is not enforced.
+	ReadTransferMaxSize *int32 `json:"read_transfer_max_size,omitempty"`
+	// Specifies the preferred multiple size for NFS read requests. This value is used to advise the client of optimal settings for the server, but is not enforced.
+	ReadTransferMultiple *int32 `json:"read_transfer_multiple,omitempty"`
+	// Specifies the preferred size for NFS read requests. This value is used to advise the client of optimal settings for the server, but is not enforced.
+	ReadTransferSize *int32 `json:"read_transfer_size,omitempty"`
+	// Specifies the clients with both read and write access to the export, even when the export is set to read-only.
+	ReadWriteClients []string `json:"read_write_clients,omitempty"`
+	// True if 'readdirplus' requests are enabled. Enabling this property might improve network performance and is only available for NFSv3.
+	Readdirplus *bool `json:"readdirplus,omitempty"`
+	// Sets the number of directory entries that are prefetched when a 'readdirplus' request is processed. (Deprecated.)
+	ReaddirplusPrefetch *int32 `json:"readdirplus_prefetch,omitempty"`
+	// Limits the size of file identifiers returned by NFSv3+ to 32-bit values (may require remount).
+	Return32bitFileIds *bool `json:"return_32bit_file_ids,omitempty"`
+	// Clients that have root access to the export.
+	RootClients []string `json:"root_clients,omitempty"`
+	// Specifies the authentication types that are supported for this export.
+	SecurityFlavors []string `json:"security_flavors,omitempty"`
+	// True if set attribute operations execute asynchronously.
+	SetattrAsynchronous *bool `json:"setattr_asynchronous,omitempty"`
+	// Specifies the snapshot for all mounts.
+	Snapshot *string `json:"snapshot,omitempty"`
+	// True if symlinks are supported. This value is used to advise the client of optimal settings for the server, but is not enforced.
+	Symlinks *bool `json:"symlinks,omitempty"`
+	// Specifies the resolution of all time values that are returned to the clients
+	TimeDelta *float32 `json:"time_delta,omitempty"`
+	// Reports clients that cannot be resolved.
+	UnresolvedClients []string `json:"unresolved_clients,omitempty"`
+	// Specifies the action to be taken when an NFSv3+ datasync write is requested.
+	WriteDatasyncAction *string `json:"write_datasync_action,omitempty"`
+	// Specifies the stability disposition returned when an NFSv3+ datasync write is processed.
+	WriteDatasyncReply *string `json:"write_datasync_reply,omitempty"`
+	// Specifies the action to be taken when an NFSv3+ filesync write is requested.
+	WriteFilesyncAction *string `json:"write_filesync_action,omitempty"`
+	// Specifies the stability disposition returned when an NFSv3+ filesync write is processed.
+	WriteFilesyncReply *string `json:"write_filesync_reply,omitempty"`
+	// Specifies the maximum buffer size that clients should use on NFS write requests. This value is used to advise the client of optimal settings for the server, but is not enforced.
+	WriteTransferMaxSize *int32 `json:"write_transfer_max_size,omitempty"`
+	// Specifies the preferred multiple size for NFS write requests. This value is used to advise the client of optimal settings for the server, but is not enforced.
+	WriteTransferMultiple *int32 `json:"write_transfer_multiple,omitempty"`
+	// Specifies the preferred multiple size for NFS write requests. This value is used to advise the client of optimal settings for the server, but is not enforced.
+	WriteTransferSize *int32 `json:"write_transfer_size,omitempty"`
+	// Specifies the action to be taken when an NFSv3+ unstable write is requested.
+	WriteUnstableAction *string `json:"write_unstable_action,omitempty"`
+	// Specifies the stability disposition returned when an NFSv3+ unstable write is processed.
+	WriteUnstableReply *string `json:"write_unstable_reply,omitempty"`
+	// Specifies the zone in which the export is valid.
+	Zone *string `json:"zone,omitempty"`
+}

--- a/openapi/model_v2_nfs_export_extended_extended.go
+++ b/openapi/model_v2_nfs_export_extended_extended.go
@@ -1,0 +1,113 @@
+/*
+	Copyright (c) 2023 Dell Inc, or its subsidiaries.
+
+	Licensed under the Apache License, Version 2.0 (the "License");
+	you may not use this file except in compliance with the License.
+	You may obtain a copy of the License at
+
+		http://www.apache.org/licenses/LICENSE-2.0
+
+	Unless required by applicable law or agreed to in writing, software
+	distributed under the License is distributed on an "AS IS" BASIS,
+	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+	See the License for the specific language governing permissions and
+	limitations under the License.
+*/
+
+package openapi
+
+// V2NfsExportExtendedExtended Specifies configuration values for NFS exports.
+type V2NfsExportExtendedExtended struct {
+	// True if all directories under the specified paths are mountable.
+	AllDirs *bool `json:"all_dirs,omitempty"`
+	// Specifies the block size returned by the NFS statfs procedure.
+	BlockSize *int32 `json:"block_size,omitempty"`
+	// True if the client can set file times through the NFS set attribute request. This parameter does not affect server behavior, but is included to accommodate legacy client requirements.
+	CanSetTime *bool `json:"can_set_time,omitempty"`
+	// True if the case is ignored for file names. This parameter does not affect server behavior, but is included to accommodate legacy client requirements.
+	CaseInsensitive *bool `json:"case_insensitive,omitempty"`
+	// True if the case is preserved for file names. This parameter does not affect server behavior, but is included to accommodate legacy client requirements.
+	CasePreserving *bool `json:"case_preserving,omitempty"`
+	// True if the superuser can change file ownership. This parameter does not affect server behavior, but is included to accommodate legacy client requirements.
+	ChownRestricted *bool `json:"chown_restricted,omitempty"`
+	// Specifies the clients with root access to the export.
+	Clients []string `json:"clients,omitempty"`
+	// True if NFS  commit  requests execute asynchronously.
+	CommitAsynchronous *bool `json:"commit_asynchronous,omitempty"`
+	// Specifies the user-defined string that is used to identify the export.
+	Description *string `json:"description,omitempty"`
+	// Specifies the preferred size for directory read operations. This value is used to advise the client of optimal settings for the server, but is not enforced.
+	DirectoryTransferSize *int32 `json:"directory_transfer_size,omitempty"`
+	// Specifies the default character set encoding of the clients connecting to the export, unless otherwise specified.
+	Encoding *string `json:"encoding,omitempty"`
+	// Specifies the reported maximum number of links to a file. This parameter does not affect server behavior, but is included to accommodate legacy client requirements.
+	LinkMax *int32 `json:"link_max,omitempty"`
+	MapAll *V2NfsExportMapAll `json:"map_all,omitempty"`
+	MapFailure *V2NfsExportMapAll `json:"map_failure,omitempty"`
+	// True if user mappings query the OneFS user database. When set to false, user mappings only query local authentication.
+	MapFull *bool `json:"map_full,omitempty"`
+	// True if incoming user IDs (UIDs) are mapped to users in the OneFS user database. When set to false, incoming UIDs are applied directly to file operations.
+	MapLookupUid *bool `json:"map_lookup_uid,omitempty"`
+	MapNonRoot *V2NfsExportMapAll `json:"map_non_root,omitempty"`
+	// Determines whether searches for users specified in 'map_all', 'map_root' or 'map_nonroot' are retried if the search fails.
+	MapRetry *bool `json:"map_retry,omitempty"`
+	MapRoot *V2NfsExportMapAll `json:"map_root,omitempty"`
+	// Specifies the maximum file size for any file accessed from the export. This parameter does not affect server behavior, but is included to accommodate legacy client requirements.
+	MaxFileSize *int64 `json:"max_file_size,omitempty"`
+	// Specifies the reported maximum length of a file name. This parameter does not affect server behavior, but is included to accommodate legacy client requirements.
+	NameMaxSize *int32 `json:"name_max_size,omitempty"`
+	// True if long file names result in an error. This parameter does not affect server behavior, but is included to accommodate legacy client requirements.
+	NoTruncate *bool `json:"no_truncate,omitempty"`
+	// Specifies the paths under /ifs that are exported.
+	Paths []string `json:"paths,omitempty"`
+	// True if the export is set to read-only.
+	ReadOnly *bool `json:"read_only,omitempty"`
+	// Specifies the clients with read-only access to the export.
+	ReadOnlyClients []string `json:"read_only_clients,omitempty"`
+	// Specifies the maximum buffer size that clients should use on NFS read requests. This value is used to advise the client of optimal settings for the server, but is not enforced.
+	ReadTransferMaxSize *int32 `json:"read_transfer_max_size,omitempty"`
+	// Specifies the preferred multiple size for NFS read requests. This value is used to advise the client of optimal settings for the server, but is not enforced.
+	ReadTransferMultiple *int32 `json:"read_transfer_multiple,omitempty"`
+	// Specifies the preferred size for NFS read requests. This value is used to advise the client of optimal settings for the server, but is not enforced.
+	ReadTransferSize *int32 `json:"read_transfer_size,omitempty"`
+	// Specifies the clients with both read and write access to the export, even when the export is set to read-only.
+	ReadWriteClients []string `json:"read_write_clients,omitempty"`
+	// True if 'readdirplus' requests are enabled. Enabling this property might improve network performance and is only available for NFSv3.
+	Readdirplus *bool `json:"readdirplus,omitempty"`
+	// Sets the number of directory entries that are prefetched when a 'readdirplus' request is processed. (Deprecated.)
+	ReaddirplusPrefetch *int32 `json:"readdirplus_prefetch,omitempty"`
+	// Limits the size of file identifiers returned by NFSv3+ to 32-bit values (may require remount).
+	Return32bitFileIds *bool `json:"return_32bit_file_ids,omitempty"`
+	// Clients that have root access to the export.
+	RootClients []string `json:"root_clients,omitempty"`
+	// Specifies the authentication types that are supported for this export.
+	SecurityFlavors []string `json:"security_flavors,omitempty"`
+	// True if set attribute operations execute asynchronously.
+	SetattrAsynchronous *bool `json:"setattr_asynchronous,omitempty"`
+	// Specifies the snapshot for all mounts.
+	Snapshot *string `json:"snapshot,omitempty"`
+	// True if symlinks are supported. This value is used to advise the client of optimal settings for the server, but is not enforced.
+	Symlinks *bool `json:"symlinks,omitempty"`
+	// Specifies the resolution of all time values that are returned to the clients
+	TimeDelta *float32 `json:"time_delta,omitempty"`
+	// Specifies the action to be taken when an NFSv3+ datasync write is requested.
+	WriteDatasyncAction *string `json:"write_datasync_action,omitempty"`
+	// Specifies the stability disposition returned when an NFSv3+ datasync write is processed.
+	WriteDatasyncReply *string `json:"write_datasync_reply,omitempty"`
+	// Specifies the action to be taken when an NFSv3+ filesync write is requested.
+	WriteFilesyncAction *string `json:"write_filesync_action,omitempty"`
+	// Specifies the stability disposition returned when an NFSv3+ filesync write is processed.
+	WriteFilesyncReply *string `json:"write_filesync_reply,omitempty"`
+	// Specifies the maximum buffer size that clients should use on NFS write requests. This value is used to advise the client of optimal settings for the server, but is not enforced.
+	WriteTransferMaxSize *int32 `json:"write_transfer_max_size,omitempty"`
+	// Specifies the preferred multiple size for NFS write requests. This value is used to advise the client of optimal settings for the server, but is not enforced.
+	WriteTransferMultiple *int32 `json:"write_transfer_multiple,omitempty"`
+	// Specifies the preferred multiple size for NFS write requests. This value is used to advise the client of optimal settings for the server, but is not enforced.
+	WriteTransferSize *int32 `json:"write_transfer_size,omitempty"`
+	// Specifies the action to be taken when an NFSv3+ unstable write is requested.
+	WriteUnstableAction *string `json:"write_unstable_action,omitempty"`
+	// Specifies the stability disposition returned when an NFSv3+ unstable write is processed.
+	WriteUnstableReply *string `json:"write_unstable_reply,omitempty"`
+	// Specifies the zone in which the export is valid.
+	Zone *string `json:"zone,omitempty"`
+}

--- a/openapi/model_v2_nfs_export_map_all.go
+++ b/openapi/model_v2_nfs_export_map_all.go
@@ -1,0 +1,27 @@
+/*
+	Copyright (c) 2023 Dell Inc, or its subsidiaries.
+
+	Licensed under the Apache License, Version 2.0 (the "License");
+	you may not use this file except in compliance with the License.
+	You may obtain a copy of the License at
+
+		http://www.apache.org/licenses/LICENSE-2.0
+
+	Unless required by applicable law or agreed to in writing, software
+	distributed under the License is distributed on an "AS IS" BASIS,
+	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+	See the License for the specific language governing permissions and
+	limitations under the License.
+*/
+
+package openapi
+
+// V2NfsExportMapAll Specifies the users and groups to which non-root and root clients are mapped.
+type V2NfsExportMapAll struct {
+	// True if the user mapping is applied.
+	Enabled *bool `json:"enabled,omitempty"`
+	PrimaryGroup *V1AuthAccessAccessItemFileGroup `json:"primary_group,omitempty"`
+	// Specifies persona properties for the secondary user group. A persona consists of either a type and name, or an ID.
+	SecondaryGroups []V2NfsExportMapAllSecondaryGroupsInner `json:"secondary_groups,omitempty"`
+	User *V1AuthAccessAccessItemFileGroup `json:"user,omitempty"`
+}

--- a/openapi/model_v2_nfs_export_map_all_secondary_groups_inner.go
+++ b/openapi/model_v2_nfs_export_map_all_secondary_groups_inner.go
@@ -1,0 +1,27 @@
+/*
+	Copyright (c) 2023 Dell Inc, or its subsidiaries.
+
+	Licensed under the Apache License, Version 2.0 (the "License");
+	you may not use this file except in compliance with the License.
+	You may obtain a copy of the License at
+
+		http://www.apache.org/licenses/LICENSE-2.0
+
+	Unless required by applicable law or agreed to in writing, software
+	distributed under the License is distributed on an "AS IS" BASIS,
+	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+	See the License for the specific language governing permissions and
+	limitations under the License.
+*/
+
+package openapi
+
+// V2NfsExportMapAllSecondaryGroupsInner Specifies properties for a persona, which consists of either a 'type' and a 'name' or an 'ID'.
+type V2NfsExportMapAllSecondaryGroupsInner struct {
+	// Specifies the serialized form of a persona, which can be 'UID:0', 'USER:name', 'GID:0', 'GROUP:wheel', or 'SID:S-1-1'.
+	Id *string `json:"id,omitempty"`
+	// Specifies the persona name, which must be combined with a type.
+	Name NullableString `json:"name,omitempty"`
+	// Specifies the type of persona, which must be combined with a name.
+	Type NullableString `json:"type,omitempty"`
+}

--- a/openapi/model_v2_nfs_exports.go
+++ b/openapi/model_v2_nfs_exports.go
@@ -1,0 +1,28 @@
+/*
+	Copyright (c) 2023 Dell Inc, or its subsidiaries.
+
+	Licensed under the Apache License, Version 2.0 (the "License");
+	you may not use this file except in compliance with the License.
+	You may obtain a copy of the License at
+
+		http://www.apache.org/licenses/LICENSE-2.0
+
+	Unless required by applicable law or agreed to in writing, software
+	distributed under the License is distributed on an "AS IS" BASIS,
+	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+	See the License for the specific language governing permissions and
+	limitations under the License.
+*/
+
+package openapi
+
+// V2NfsExports struct for V2NfsExports
+type V2NfsExports struct {
+	// An identifier for a set of exports.
+	Digest *string `json:"digest,omitempty"`
+	Exports []V2NfsExportExtended `json:"exports,omitempty"`
+	// Provide this token as the 'resume' query argument to continue listing results.
+	Resume *string `json:"resume,omitempty"`
+	// Total number of items available.
+	Total *int32 `json:"total,omitempty"`
+}

--- a/openapi/model_v2_nfs_exports_extended.go
+++ b/openapi/model_v2_nfs_exports_extended.go
@@ -1,0 +1,22 @@
+/*
+	Copyright (c) 2023 Dell Inc, or its subsidiaries.
+
+	Licensed under the Apache License, Version 2.0 (the "License");
+	you may not use this file except in compliance with the License.
+	You may obtain a copy of the License at
+
+		http://www.apache.org/licenses/LICENSE-2.0
+
+	Unless required by applicable law or agreed to in writing, software
+	distributed under the License is distributed on an "AS IS" BASIS,
+	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+	See the License for the specific language governing permissions and
+	limitations under the License.
+*/
+
+package openapi
+
+// V2NfsExportsExtended struct for V2NfsExportsExtended
+type V2NfsExportsExtended struct {
+	Exports []V2NfsExportExtended `json:"exports,omitempty"`
+}

--- a/openapi/utils.go
+++ b/openapi/utils.go
@@ -1,0 +1,353 @@
+/*
+	Copyright (c) 2023 Dell Inc, or its subsidiaries.
+
+	Licensed under the Apache License, Version 2.0 (the "License");
+	you may not use this file except in compliance with the License.
+	You may obtain a copy of the License at
+
+		http://www.apache.org/licenses/LICENSE-2.0
+
+	Unless required by applicable law or agreed to in writing, software
+	distributed under the License is distributed on an "AS IS" BASIS,
+	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+	See the License for the specific language governing permissions and
+	limitations under the License.
+*/
+
+package openapi
+
+import (
+	"encoding/json"
+	"reflect"
+	"time"
+)
+
+// PtrBool is a helper routine that returns a pointer to given boolean value.
+func PtrBool(v bool) *bool { return &v }
+
+// PtrInt is a helper routine that returns a pointer to given integer value.
+func PtrInt(v int) *int { return &v }
+
+// PtrInt32 is a helper routine that returns a pointer to given integer value.
+func PtrInt32(v int32) *int32 { return &v }
+
+// PtrInt64 is a helper routine that returns a pointer to given integer value.
+func PtrInt64(v int64) *int64 { return &v }
+
+// PtrFloat32 is a helper routine that returns a pointer to given float value.
+func PtrFloat32(v float32) *float32 { return &v }
+
+// PtrFloat64 is a helper routine that returns a pointer to given float value.
+func PtrFloat64(v float64) *float64 { return &v }
+
+// PtrString is a helper routine that returns a pointer to given string value.
+func PtrString(v string) *string { return &v }
+
+// PtrTime is helper routine that returns a pointer to given Time value.
+func PtrTime(v time.Time) *time.Time { return &v }
+
+type NullableBool struct {
+	value *bool
+	isSet bool
+}
+
+func (v NullableBool) Get() *bool {
+	return v.value
+}
+
+func (v *NullableBool) Set(val *bool) {
+	v.value = val
+	v.isSet = true
+}
+
+func (v NullableBool) IsSet() bool {
+	return v.isSet
+}
+
+func (v *NullableBool) Unset() {
+	v.value = nil
+	v.isSet = false
+}
+
+func NewNullableBool(val *bool) *NullableBool {
+	return &NullableBool{value: val, isSet: true}
+}
+
+func (v NullableBool) MarshalJSON() ([]byte, error) {
+	return json.Marshal(v.value)
+}
+
+func (v *NullableBool) UnmarshalJSON(src []byte) error {
+	v.isSet = true
+	return json.Unmarshal(src, &v.value)
+}
+
+type NullableInt struct {
+	value *int
+	isSet bool
+}
+
+func (v NullableInt) Get() *int {
+	return v.value
+}
+
+func (v *NullableInt) Set(val *int) {
+	v.value = val
+	v.isSet = true
+}
+
+func (v NullableInt) IsSet() bool {
+	return v.isSet
+}
+
+func (v *NullableInt) Unset() {
+	v.value = nil
+	v.isSet = false
+}
+
+func NewNullableInt(val *int) *NullableInt {
+	return &NullableInt{value: val, isSet: true}
+}
+
+func (v NullableInt) MarshalJSON() ([]byte, error) {
+	return json.Marshal(v.value)
+}
+
+func (v *NullableInt) UnmarshalJSON(src []byte) error {
+	v.isSet = true
+	return json.Unmarshal(src, &v.value)
+}
+
+type NullableInt32 struct {
+	value *int32
+	isSet bool
+}
+
+func (v NullableInt32) Get() *int32 {
+	return v.value
+}
+
+func (v *NullableInt32) Set(val *int32) {
+	v.value = val
+	v.isSet = true
+}
+
+func (v NullableInt32) IsSet() bool {
+	return v.isSet
+}
+
+func (v *NullableInt32) Unset() {
+	v.value = nil
+	v.isSet = false
+}
+
+func NewNullableInt32(val *int32) *NullableInt32 {
+	return &NullableInt32{value: val, isSet: true}
+}
+
+func (v NullableInt32) MarshalJSON() ([]byte, error) {
+	return json.Marshal(v.value)
+}
+
+func (v *NullableInt32) UnmarshalJSON(src []byte) error {
+	v.isSet = true
+	return json.Unmarshal(src, &v.value)
+}
+
+type NullableInt64 struct {
+	value *int64
+	isSet bool
+}
+
+func (v NullableInt64) Get() *int64 {
+	return v.value
+}
+
+func (v *NullableInt64) Set(val *int64) {
+	v.value = val
+	v.isSet = true
+}
+
+func (v NullableInt64) IsSet() bool {
+	return v.isSet
+}
+
+func (v *NullableInt64) Unset() {
+	v.value = nil
+	v.isSet = false
+}
+
+func NewNullableInt64(val *int64) *NullableInt64 {
+	return &NullableInt64{value: val, isSet: true}
+}
+
+func (v NullableInt64) MarshalJSON() ([]byte, error) {
+	return json.Marshal(v.value)
+}
+
+func (v *NullableInt64) UnmarshalJSON(src []byte) error {
+	v.isSet = true
+	return json.Unmarshal(src, &v.value)
+}
+
+type NullableFloat32 struct {
+	value *float32
+	isSet bool
+}
+
+func (v NullableFloat32) Get() *float32 {
+	return v.value
+}
+
+func (v *NullableFloat32) Set(val *float32) {
+	v.value = val
+	v.isSet = true
+}
+
+func (v NullableFloat32) IsSet() bool {
+	return v.isSet
+}
+
+func (v *NullableFloat32) Unset() {
+	v.value = nil
+	v.isSet = false
+}
+
+func NewNullableFloat32(val *float32) *NullableFloat32 {
+	return &NullableFloat32{value: val, isSet: true}
+}
+
+func (v NullableFloat32) MarshalJSON() ([]byte, error) {
+	return json.Marshal(v.value)
+}
+
+func (v *NullableFloat32) UnmarshalJSON(src []byte) error {
+	v.isSet = true
+	return json.Unmarshal(src, &v.value)
+}
+
+type NullableFloat64 struct {
+	value *float64
+	isSet bool
+}
+
+func (v NullableFloat64) Get() *float64 {
+	return v.value
+}
+
+func (v *NullableFloat64) Set(val *float64) {
+	v.value = val
+	v.isSet = true
+}
+
+func (v NullableFloat64) IsSet() bool {
+	return v.isSet
+}
+
+func (v *NullableFloat64) Unset() {
+	v.value = nil
+	v.isSet = false
+}
+
+func NewNullableFloat64(val *float64) *NullableFloat64 {
+	return &NullableFloat64{value: val, isSet: true}
+}
+
+func (v NullableFloat64) MarshalJSON() ([]byte, error) {
+	return json.Marshal(v.value)
+}
+
+func (v *NullableFloat64) UnmarshalJSON(src []byte) error {
+	v.isSet = true
+	return json.Unmarshal(src, &v.value)
+}
+
+type NullableString struct {
+	value *string
+	isSet bool
+}
+
+func (v NullableString) Get() *string {
+	return v.value
+}
+
+func (v *NullableString) Set(val *string) {
+	v.value = val
+	v.isSet = true
+}
+
+func (v NullableString) IsSet() bool {
+	return v.isSet
+}
+
+func (v *NullableString) Unset() {
+	v.value = nil
+	v.isSet = false
+}
+
+func NewNullableString(val *string) *NullableString {
+	return &NullableString{value: val, isSet: true}
+}
+
+func (v NullableString) MarshalJSON() ([]byte, error) {
+	return json.Marshal(v.value)
+}
+
+func (v *NullableString) UnmarshalJSON(src []byte) error {
+	v.isSet = true
+	return json.Unmarshal(src, &v.value)
+}
+
+type NullableTime struct {
+	value *time.Time
+	isSet bool
+}
+
+func (v NullableTime) Get() *time.Time {
+	return v.value
+}
+
+func (v *NullableTime) Set(val *time.Time) {
+	v.value = val
+	v.isSet = true
+}
+
+func (v NullableTime) IsSet() bool {
+	return v.isSet
+}
+
+func (v *NullableTime) Unset() {
+	v.value = nil
+	v.isSet = false
+}
+
+func NewNullableTime(val *time.Time) *NullableTime {
+	return &NullableTime{value: val, isSet: true}
+}
+
+func (v NullableTime) MarshalJSON() ([]byte, error) {
+	return v.value.MarshalJSON()
+}
+
+func (v *NullableTime) UnmarshalJSON(src []byte) error {
+	v.isSet = true
+	return json.Unmarshal(src, &v.value)
+}
+
+// IsNil checks if an input is nil
+func IsNil(i interface{}) bool {
+	if i == nil {
+		return true
+	}
+	switch reflect.TypeOf(i).Kind() {
+	case reflect.Chan, reflect.Func, reflect.Map, reflect.Ptr, reflect.UnsafePointer, reflect.Interface, reflect.Slice:
+		return reflect.ValueOf(i).IsNil()
+	case reflect.Array:
+		return reflect.ValueOf(i).IsZero()
+	}
+	return false
+}
+
+type MappedNullable interface {
+	ToMap() (map[string]interface{}, error)
+}

--- a/shares.go
+++ b/shares.go
@@ -1,0 +1,66 @@
+/*
+	Copyright (c) 2023 Dell Inc, or its subsidiaries.
+
+	Licensed under the Apache License, Version 2.0 (the "License");
+	you may not use this file except in compliance with the License.
+	You may obtain a copy of the License at
+
+		http://www.apache.org/licenses/LICENSE-2.0
+
+	Unless required by applicable law or agreed to in writing, software
+	distributed under the License is distributed on an "AS IS" BASIS,
+	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+	See the License for the specific language governing permissions and
+	limitations under the License.
+*/
+package goisilon
+
+import (
+	"context"
+	apiv12 "github.com/dell/goisilon/api/v12"
+	"github.com/dell/goisilon/openapi"
+)
+
+// ListALlSmbSharesWithStructParams returns all the smb shares with params
+func (c *Client) ListALlSmbSharesWithStructParams(ctx context.Context, params apiv12.ListV12SmbSharesParams) ([]openapi.V12SmbShareExtended, error) {
+	var result []openapi.V12SmbShareExtended
+	shares, err := apiv12.ListSmbShares(ctx, params, c.API)
+	if err != nil {
+		return nil, err
+	}
+	result = shares.Shares
+	for shares.Resume != nil {
+		resumeParam := apiv12.ListV12SmbSharesParams{Resume: shares.Resume}
+		shares, err = apiv12.ListSmbShares(ctx, resumeParam, c.API)
+		if err != nil {
+			return nil, err
+		}
+		result = append(result, shares.Shares...)
+	}
+	return result, nil
+}
+
+// ListSmbSharesWithStructParams returns the smb shares with params
+func (c *Client) ListSmbSharesWithStructParams(ctx context.Context, params apiv12.ListV12SmbSharesParams) (*openapi.V12SmbShares, error) {
+	return apiv12.ListSmbShares(ctx, params, c.API)
+}
+
+// GetSmbShareWithStructParams return the specific smb share with params
+func (c *Client) GetSmbShareWithStructParams(ctx context.Context, params apiv12.GetV12SmbShareParams) (*openapi.V12SmbSharesExtended, error) {
+	return apiv12.GetSmbShare(ctx, params, c.API)
+}
+
+// CreateSmbShareWithStructParams creates a smb share with params
+func (c *Client) CreateSmbShareWithStructParams(ctx context.Context, params apiv12.CreateV12SmbShareRequest) (*openapi.Createv12SmbShareResponse, error) {
+	return apiv12.CreateSmbShare(ctx, params, c.API)
+}
+
+// DeleteSmbShareWithStructParams delete a specific smb share with params6570
+func (c *Client) DeleteSmbShareWithStructParams(ctx context.Context, params apiv12.DeleteV12SmbShareRequest) error {
+	return apiv12.DeleteSmbShare(ctx, params, c.API)
+}
+
+// UpdateSmbShareWithStructParams updates a smb share with params
+func (c *Client) UpdateSmbShareWithStructParams(ctx context.Context, params apiv12.UpdateV12SmbShareRequest) error {
+	return apiv12.UpdateSmbShare(ctx, params, c.API)
+}

--- a/shares_test.go
+++ b/shares_test.go
@@ -1,0 +1,99 @@
+/*
+	Copyright (c) 2023 Dell Inc, or its subsidiaries.
+
+	Licensed under the Apache License, Version 2.0 (the "License");
+	you may not use this file except in compliance with the License.
+	You may obtain a copy of the License at
+
+		http://www.apache.org/licenses/LICENSE-2.0
+
+	Unless required by applicable law or agreed to in writing, software
+	distributed under the License is distributed on an "AS IS" BASIS,
+	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+	See the License for the specific language governing permissions and
+	limitations under the License.
+*/
+package goisilon
+
+import (
+	v12 "github.com/dell/goisilon/api/v12"
+	"github.com/dell/goisilon/openapi"
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestClient_SmbShareWithStructParams(t *testing.T) {
+	// use limit to test pagination, would still output all shares
+	limit := int32(1)
+	_, err := client.ListALlSmbSharesWithStructParams(defaultCtx, v12.ListV12SmbSharesParams{
+		Limit: &limit,
+	})
+	assertNil(t, err)
+}
+
+func TestClient_SmbShareLifeCycleWithStructParams(t *testing.T) {
+	trusteeId := "SID:S-1-1-0"
+	trusteeName := "Everyone"
+	trusteeType := "wellknown"
+	shareName := "tf_share"
+	createResponse, err := client.CreateSmbShareWithStructParams(defaultCtx, v12.CreateV12SmbShareRequest{
+		V12SmbShare: &openapi.V12SmbShare{
+			Name: shareName,
+			Path: "/ifs/data",
+			Permissions: []openapi.V1SmbSharePermission{{
+				Permission:     "full",
+				PermissionType: "allow",
+				Trustee: openapi.V1AuthAccessAccessItemFileGroup{
+					Id:   &trusteeId,
+					Name: &trusteeName,
+					Type: &trusteeType,
+				},
+			}},
+		},
+	})
+	assertNil(t, err)
+	assert.Equal(t, shareName, createResponse.Id)
+
+	// Test list SMB
+	limit := int32(1)
+	getShares, err := client.ListSmbSharesWithStructParams(defaultCtx, v12.ListV12SmbSharesParams{
+		Limit: &limit,
+	})
+	assertNil(t, err)
+	assert.Equal(t, 1, len(getShares.Shares))
+
+	// Test get SMB
+	getShare, err := client.GetSmbShareWithStructParams(defaultCtx, v12.GetV12SmbShareParams{
+		V12SmbShareId: shareName,
+	})
+	assertNil(t, err)
+	assert.NotZero(t, len(getShare.Shares))
+	assert.Equal(t, shareName, getShare.Shares[0].Name)
+
+	// Test update SMB
+	updateCaTimeout := int32(112)
+	err = client.UpdateSmbShareWithStructParams(defaultCtx, v12.UpdateV12SmbShareRequest{
+		V12SmbShareId: shareName,
+		V12SmbShare: &openapi.V12SmbShareExtendedExtended{
+			CaTimeout: &updateCaTimeout,
+		},
+	})
+	assertNil(t, err)
+	getShare, err = client.GetSmbShareWithStructParams(defaultCtx, v12.GetV12SmbShareParams{
+		V12SmbShareId: shareName,
+	})
+	assertNil(t, err)
+	assert.NotZero(t, len(getShare.Shares))
+	assert.Equal(t, &updateCaTimeout, getShare.Shares[0].CaTimeout)
+
+	// Test Delete SMB
+	err = client.DeleteSmbShareWithStructParams(defaultCtx, v12.DeleteV12SmbShareRequest{
+		V12SmbShareId: shareName,
+	})
+	assertNil(t, err)
+	// ensure smb is cleaned
+	getShare, err = client.GetSmbShareWithStructParams(defaultCtx, v12.GetV12SmbShareParams{
+		V12SmbShareId: shareName,
+	})
+	assertNotNil(t, err)
+}


### PR DESCRIPTION
Use structs generated by Open API to implement nfs exports and smb share Add testing codes

# PR Submission checklist

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
|https://github.com/dell/csm/issues/888|

# Common PR Checklist:

- [x] Have you made sure that the code compiles?
- [x] Have you commented your code, particularly in hard-to-understand areas
- [ ] Did you run tests in a real Kubernetes cluster?
- [x] Have you maintained backward compatibility

# Tests:
```
time="2023-07-10T03:09:02-04:00" level=debug msg="opts.Insecure : 'true'"
time="2023-07-10T03:09:02-04:00" level=debug msg="\n    -------------------------- GOISILON HTTP REQUEST -------------------------\n    GET /platform/latest/ HTTP/1.1\n    Host: 10.230.24.241:8080\n    Authorization: root:******\n    \n"
time="2023-07-10T03:09:03-04:00" level=debug msg="\n    -------------------------- GOISILON HTTP RESPONSE -------------------------\n    HTTP/1.1 200 Ok\n    Transfer-Encoding: chunked\n    Content-Security-Policy: default-src 'self' 'unsafe-inline' 'unsafe-eval' data:; script-src 'self' 'unsafe-eval'; style-src 'unsafe-inline' 'self';\n    Content-Type: application/json\n    Date: Mon, 10 Jul 2023 07:09:05 GMT\n    Server: Apache\n    Strict-Transport-Security: max-age=31536000;\n    X-Content-Type-Options: nosniff\n    X-Frame-Options: sameorigin\n    X-Xss-Protection: 1; mode=block\n    "
**=== RUN   TestClient_ListExportsWithStructParams**
time="2023-07-10T03:09:03-04:00" level=debug msg="\n    -------------------------- GOISILON HTTP REQUEST -------------------------\n    GET /platform/4/protocols/nfs/exports/?limit=600 HTTP/1.1\n    Host: 10.230.24.241:8080\n    Authorization: root:******\n    \n"
time="2023-07-10T03:09:03-04:00" level=debug msg="\n    -------------------------- GOISILON HTTP RESPONSE -------------------------\n    HTTP/1.1 200 Ok\n    Transfer-Encoding: chunked\n    Allow: GET, POST, HEAD\n    Content-Security-Policy: default-src 'self' 'unsafe-inline' 'unsafe-eval' data:; script-src 'self' 'unsafe-eval'; style-src 'unsafe-inline' 'self';\n    Content-Type: application/json\n    Date: Mon, 10 Jul 2023 07:09:05 GMT\n    Server: Apache\n    Strict-Transport-Security: max-age=31536000;\n    X-Content-Type-Options: nosniff\n    X-Frame-Options: sameorigin\n    X-Xss-Protection: 1; mode=block\n    "
time="2023-07-10T03:09:03-04:00" level=debug msg="\n    -------------------------- GOISILON HTTP REQUEST -------------------------\n    GET /platform/4/protocols/nfs/exports/?resume=1-1-MAAA1-MAAA6-MjA3MDg33-NjAw3-NjAw0-1-MgAA2-aWQA6-MjA3MDg332-YmUzYTI0NDdhZGE1ZDZlMmVkNjc0YjUxM2UxMmJjMzAA1-MQAA HTTP/1.1\n    Host: 10.230.24.241:8080\n    Authorization: root:******\n    \n"
time="2023-07-10T03:09:04-04:00" level=debug msg="\n    -------------------------- GOISILON HTTP RESPONSE -------------------------\n    HTTP/1.1 200 Ok\n    Transfer-Encoding: chunked\n    Allow: GET, POST, HEAD\n    Content-Security-Policy: default-src 'self' 'unsafe-inline' 'unsafe-eval' data:; script-src 'self' 'unsafe-eval'; style-src 'unsafe-inline' 'self';\n    Content-Type: application/json\n    Date: Mon, 10 Jul 2023 07:09:06 GMT\n    Server: Apache\n    Strict-Transport-Security: max-age=31536000;\n    X-Content-Type-Options: nosniff\n    X-Frame-Options: sameorigin\n    X-Xss-Protection: 1; mode=block\n    "
**--- PASS: TestClient_ListExportsWithStructParams (1.09s)**
**=== RUN   TestClient_ExportLifeCycleWithStructParams**
time="2023-07-10T03:09:04-04:00" level=debug msg="\n    -------------------------- GOISILON HTTP REQUEST -------------------------\n    PUT /namespace/ifs/data/tf_nfs_export_test HTTP/1.1\n    Host: 10.230.24.241:8080\n    Authorization: root:******\n    X-Isi-Ifs-Access-Control: 0777\n    X-Isi-Ifs-Target-Type: container\n    \n"
time="2023-07-10T03:09:04-04:00" level=debug msg="\n    -------------------------- GOISILON HTTP RESPONSE -------------------------\n    HTTP/1.1 200 Ok\n    Transfer-Encoding: chunked\n    Allow: GET, PUT, POST, DELETE, HEAD\n    Content-Security-Policy: default-src 'none'\n    Content-Type: text/plain\n    Date: Mon, 10 Jul 2023 07:09:06 GMT\n    Server: Apache\n    Strict-Transport-Security: max-age=31536000;\n    X-Content-Type-Options: nosniff\n    X-Frame-Options: sameorigin\n    X-Isi-Ifs-Spec-Version: 1.0\n    X-Xss-Protection: 1; mode=block\n    "
time="2023-07-10T03:09:04-04:00" level=debug msg="\n    -------------------------- GOISILON HTTP REQUEST -------------------------\n    POST /platform/4/protocols/nfs/exports/ HTTP/1.1\n    Host: 10.230.24.241:8080\n    Authorization: root:******\n    Content-Type: application/json\n    \n    {\"paths\":[\"/ifs/data/tf_nfs_export_test\"]}\n"
time="2023-07-10T03:09:04-04:00" level=debug msg="\n    -------------------------- GOISILON HTTP RESPONSE -------------------------\n    HTTP/1.1 201 Created\n    Transfer-Encoding: chunked\n    Allow: GET, POST, HEAD\n    Content-Security-Policy: default-src 'self' 'unsafe-inline' 'unsafe-eval' data:; script-src 'self' 'unsafe-eval'; style-src 'unsafe-inline' 'self';\n    Content-Type: application/json\n    Date: Mon, 10 Jul 2023 07:09:06 GMT\n    Location: /4/protocols/nfs/exports/302182\n    Server: Apache\n    Strict-Transport-Security: max-age=31536000;\n    X-Content-Type-Options: nosniff\n    X-Frame-Options: sameorigin\n    X-Xss-Protection: 1; mode=block\n    "
time="2023-07-10T03:09:04-04:00" level=debug msg="\n    -------------------------- GOISILON HTTP REQUEST -------------------------\n    GET /platform/4/protocols/nfs/exports/?limit=1 HTTP/1.1\n    Host: 10.230.24.241:8080\n    Authorization: root:******\n    \n"
time="2023-07-10T03:09:04-04:00" level=debug msg="\n    -------------------------- GOISILON HTTP RESPONSE -------------------------\n    HTTP/1.1 200 Ok\n    Transfer-Encoding: chunked\n    Allow: GET, POST, HEAD\n    Content-Security-Policy: default-src 'self' 'unsafe-inline' 'unsafe-eval' data:; script-src 'self' 'unsafe-eval'; style-src 'unsafe-inline' 'self';\n    Content-Type: application/json\n    Date: Mon, 10 Jul 2023 07:09:07 GMT\n    Server: Apache\n    Strict-Transport-Security: max-age=31536000;\n    X-Content-Type-Options: nosniff\n    X-Frame-Options: sameorigin\n    X-Xss-Protection: 1; mode=block\n    "
time="2023-07-10T03:09:04-04:00" level=debug msg="\n    -------------------------- GOISILON HTTP REQUEST -------------------------\n    GET /platform/4/protocols/nfs/exports/302182 HTTP/1.1\n    Host: 10.230.24.241:8080\n    Authorization: root:******\n    \n"
time="2023-07-10T03:09:05-04:00" level=debug msg="\n    -------------------------- GOISILON HTTP RESPONSE -------------------------\n    HTTP/1.1 200 Ok\n    Transfer-Encoding: chunked\n    Allow: GET, PUT, DELETE, HEAD\n    Content-Security-Policy: default-src 'self' 'unsafe-inline' 'unsafe-eval' data:; script-src 'self' 'unsafe-eval'; style-src 'unsafe-inline' 'self';\n    Content-Type: application/json\n    Date: Mon, 10 Jul 2023 07:09:07 GMT\n    Server: Apache\n    Strict-Transport-Security: max-age=31536000;\n    X-Content-Type-Options: nosniff\n    X-Frame-Options: sameorigin\n    X-Xss-Protection: 1; mode=block\n    "
time="2023-07-10T03:09:05-04:00" level=debug msg="\n    -------------------------- GOISILON HTTP REQUEST -------------------------\n    PUT /platform/4/protocols/nfs/exports/302182 HTTP/1.1\n    Host: 10.230.24.241:8080\n    Authorization: root:******\n    Content-Type: application/json\n    \n    {\"read_only\":true}\n"
time="2023-07-10T03:09:05-04:00" level=debug msg="\n    -------------------------- GOISILON HTTP RESPONSE -------------------------\n    HTTP/1.1 204 No Content\n    Content-Length: 0\n    Allow: GET, PUT, DELETE, HEAD\n    Content-Security-Policy: default-src 'self' 'unsafe-inline' 'unsafe-eval' data:; script-src 'self' 'unsafe-eval'; style-src 'unsafe-inline' 'self';\n    Date: Mon, 10 Jul 2023 07:09:07 GMT\n    Server: Apache\n    Strict-Transport-Security: max-age=31536000;\n    X-Content-Type-Options: nosniff\n    X-Frame-Options: sameorigin\n    X-Xss-Protection: 1; mode=block\n    "
time="2023-07-10T03:09:05-04:00" level=debug msg="\n    -------------------------- GOISILON HTTP REQUEST -------------------------\n    GET /platform/4/protocols/nfs/exports/302182 HTTP/1.1\n    Host: 10.230.24.241:8080\n    Authorization: root:******\n    \n"
time="2023-07-10T03:09:05-04:00" level=debug msg="\n    -------------------------- GOISILON HTTP RESPONSE -------------------------\n    HTTP/1.1 200 Ok\n    Transfer-Encoding: chunked\n    Allow: GET, PUT, DELETE, HEAD\n    Content-Security-Policy: default-src 'self' 'unsafe-inline' 'unsafe-eval' data:; script-src 'self' 'unsafe-eval'; style-src 'unsafe-inline' 'self';\n    Content-Type: application/json\n    Date: Mon, 10 Jul 2023 07:09:07 GMT\n    Server: Apache\n    Strict-Transport-Security: max-age=31536000;\n    X-Content-Type-Options: nosniff\n    X-Frame-Options: sameorigin\n    X-Xss-Protection: 1; mode=block\n    "
time="2023-07-10T03:09:05-04:00" level=debug msg="\n    -------------------------- GOISILON HTTP REQUEST -------------------------\n    DELETE /platform/4/protocols/nfs/exports/302182 HTTP/1.1\n    Host: 10.230.24.241:8080\n    Authorization: root:******\n    \n"
time="2023-07-10T03:09:05-04:00" level=debug msg="\n    -------------------------- GOISILON HTTP RESPONSE -------------------------\n    HTTP/1.1 204 No Content\n    Allow: GET, PUT, DELETE, HEAD\n    Content-Security-Policy: default-src 'self' 'unsafe-inline' 'unsafe-eval' data:; script-src 'self' 'unsafe-eval'; style-src 'unsafe-inline' 'self';\n    Date: Mon, 10 Jul 2023 07:09:07 GMT\n    Server: Apache\n    Strict-Transport-Security: max-age=31536000;\n    X-Content-Type-Options: nosniff\n    X-Frame-Options: sameorigin\n    X-Xss-Protection: 1; mode=block\n    "
time="2023-07-10T03:09:05-04:00" level=debug msg="\n    -------------------------- GOISILON HTTP REQUEST -------------------------\n    GET /platform/4/protocols/nfs/exports/302182 HTTP/1.1\n    Host: 10.230.24.241:8080\n    Authorization: root:******\n    \n"
time="2023-07-10T03:09:05-04:00" level=debug msg="\n    -------------------------- GOISILON HTTP RESPONSE -------------------------\n    HTTP/1.1 404 Not Found\n    Transfer-Encoding: chunked\n    Allow: GET, PUT, DELETE, HEAD\n    Content-Security-Policy: default-src 'self' 'unsafe-inline' 'unsafe-eval' data:; script-src 'self' 'unsafe-eval'; style-src 'unsafe-inline' 'self';\n    Content-Type: application/json\n    Date: Mon, 10 Jul 2023 07:09:07 GMT\n    Server: Apache\n    Strict-Transport-Security: max-age=31536000;\n    X-Content-Type-Options: nosniff\n    X-Frame-Options: sameorigin\n    X-Xss-Protection: 1; mode=block\n    "
time="2023-07-10T03:09:05-04:00" level=debug msg="\n    -------------------------- GOISILON HTTP REQUEST -------------------------\n    DELETE /namespace/ifs/data/tf_nfs_export_test?recursive=true HTTP/1.1\n    Host: 10.230.24.241:8080\n    Authorization: root:******\n    \n"
time="2023-07-10T03:09:05-04:00" level=debug msg="\n    -------------------------- GOISILON HTTP RESPONSE -------------------------\n    HTTP/1.1 204 No Content\n    Allow: GET, PUT, POST, DELETE, HEAD\n    Content-Security-Policy: default-src 'none'\n    Date: Mon, 10 Jul 2023 07:09:08 GMT\n    Server: Apache\n    Strict-Transport-Security: max-age=31536000;\n    X-Content-Type-Options: nosniff\n    X-Frame-Options: sameorigin\n    X-Isi-Ifs-Spec-Version: 1.0\n    X-Xss-Protection: 1; mode=block\n    "
time="2023-07-10T03:09:05-04:00" level=debug msg="\n    -------------------------- GOISILON HTTP REQUEST -------------------------\n    DELETE /namespace/ifs/data/tf_nfs_export_test?recursive=true HTTP/1.1\n    Host: 10.230.24.241:8080\n    Authorization: root:******\n    \n"
time="2023-07-10T03:09:05-04:00" level=debug msg="\n    -------------------------- GOISILON HTTP RESPONSE -------------------------\n    HTTP/1.1 204 No Content\n    Allow: GET, PUT, POST, DELETE, HEAD\n    Content-Security-Policy: default-src 'none'\n    Date: Mon, 10 Jul 2023 07:09:08 GMT\n    Server: Apache\n    Strict-Transport-Security: max-age=31536000;\n    X-Content-Type-Options: nosniff\n    X-Frame-Options: sameorigin\n    X-Isi-Ifs-Spec-Version: 1.0\n    X-Xss-Protection: 1; mode=block\n    "
**--- PASS: TestClient_ExportLifeCycleWithStructParams (1.50s)**
**=== RUN   TestClient_SmbShareWithStructParams**
time="2023-07-10T03:09:05-04:00" level=debug msg="\n    -------------------------- GOISILON HTTP REQUEST -------------------------\n    GET /platform/12/protocols/smb/shares/?limit=1 HTTP/1.1\n    Host: 10.230.24.241:8080\n    Authorization: root:******\n    \n"
time="2023-07-10T03:09:06-04:00" level=debug msg="\n    -------------------------- GOISILON HTTP RESPONSE -------------------------\n    HTTP/1.1 200 Ok\n    Transfer-Encoding: chunked\n    Allow: GET, POST, DELETE, HEAD\n    Content-Security-Policy: default-src 'self' 'unsafe-inline' 'unsafe-eval' data:; script-src 'self' 'unsafe-eval'; style-src 'unsafe-inline' 'self';\n    Content-Type: application/json\n    Date: Mon, 10 Jul 2023 07:09:08 GMT\n    Server: Apache\n    Strict-Transport-Security: max-age=31536000;\n    X-Content-Type-Options: nosniff\n    X-Frame-Options: sameorigin\n    X-Xss-Protection: 1; mode=block\n    "
time="2023-07-10T03:09:06-04:00" level=debug msg="\n    -------------------------- GOISILON HTTP REQUEST -------------------------\n    GET /platform/12/protocols/smb/shares/?resume=1-1-MAAA1-MAAA1-MQAA1-MQAA1-MgAA0-1-MQAA32-ZThlYTk2Y2Q3YTkyYTc0MGQ4YTM4M2JlOGI0MTMzYTUA6-cHRyX3Rm6-cHRyX3Rm HTTP/1.1\n    Host: 10.230.24.241:8080\n    Authorization: root:******\n    \n"
time="2023-07-10T03:09:06-04:00" level=debug msg="\n    -------------------------- GOISILON HTTP RESPONSE -------------------------\n    HTTP/1.1 200 Ok\n    Transfer-Encoding: chunked\n    Allow: GET, POST, DELETE, HEAD\n    Content-Security-Policy: default-src 'self' 'unsafe-inline' 'unsafe-eval' data:; script-src 'self' 'unsafe-eval'; style-src 'unsafe-inline' 'self';\n    Content-Type: application/json\n    Date: Mon, 10 Jul 2023 07:09:08 GMT\n    Server: Apache\n    Strict-Transport-Security: max-age=31536000;\n    X-Content-Type-Options: nosniff\n    X-Frame-Options: sameorigin\n    X-Xss-Protection: 1; mode=block\n    "
time="2023-07-10T03:09:06-04:00" level=debug msg="\n    -------------------------- GOISILON HTTP REQUEST -------------------------\n    GET /platform/12/protocols/smb/shares/?resume=1-1-MAAA1-MAAA1-MQAA1-MgAA1-MgAA0-1-MQAA32-ZThlYTk2Y2Q3YTkyYTc0MGQ4YTM4M2JlOGI0MTMzYTUA13-c2hhcmVfaW5oZXJpdAAA13-c2hhcmVfaW5oZXJpdAAA HTTP/1.1\n    Host: 10.230.24.241:8080\n    Authorization: root:******\n    \n"
time="2023-07-10T03:09:06-04:00" level=debug msg="\n    -------------------------- GOISILON HTTP RESPONSE -------------------------\n    HTTP/1.1 200 Ok\n    Transfer-Encoding: chunked\n    Allow: GET, POST, DELETE, HEAD\n    Content-Security-Policy: default-src 'self' 'unsafe-inline' 'unsafe-eval' data:; script-src 'self' 'unsafe-eval'; style-src 'unsafe-inline' 'self';\n    Content-Type: application/json\n    Date: Mon, 10 Jul 2023 07:09:08 GMT\n    Server: Apache\n    Strict-Transport-Security: max-age=31536000;\n    X-Content-Type-Options: nosniff\n    X-Frame-Options: sameorigin\n    X-Xss-Protection: 1; mode=block\n    "
time="2023-07-10T03:09:06-04:00" level=debug msg="\n    -------------------------- GOISILON HTTP REQUEST -------------------------\n    GET /platform/12/protocols/smb/shares/?resume=1-1-MAAA1-MAAA1-MQAA1-MwAA1-MgAA0-1-MQAA32-ZThlYTk2Y2Q3YTkyYTc0MGQ4YTM4M2JlOGI0MTMzYTUA10-dGVzdF9zaGFyZQAA10-dGVzdF9zaGFyZQAA HTTP/1.1\n    Host: 10.230.24.241:8080\n    Authorization: root:******\n    \n"
time="2023-07-10T03:09:06-04:00" level=debug msg="\n    -------------------------- GOISILON HTTP RESPONSE -------------------------\n    HTTP/1.1 200 Ok\n    Transfer-Encoding: chunked\n    Allow: GET, POST, DELETE, HEAD\n    Content-Security-Policy: default-src 'self' 'unsafe-inline' 'unsafe-eval' data:; script-src 'self' 'unsafe-eval'; style-src 'unsafe-inline' 'self';\n    Content-Type: application/json\n    Date: Mon, 10 Jul 2023 07:09:08 GMT\n    Server: Apache\n    Strict-Transport-Security: max-age=31536000;\n    X-Content-Type-Options: nosniff\n    X-Frame-Options: sameorigin\n    X-Xss-Protection: 1; mode=block\n    "
**--- PASS: TestClient_SmbShareWithStructParams (1.01s)**
**=== RUN   TestClient_SmbShareLifeCycleWithStructParams**
time="2023-07-10T03:09:06-04:00" level=debug msg="\n    -------------------------- GOISILON HTTP REQUEST -------------------------\n    POST /platform/12/protocols/smb/shares/ HTTP/1.1\n    Host: 10.230.24.241:8080\n    Authorization: root:******\n    Content-Type: application/json\n    \n    {\"name\":\"tf_share\",\"path\":\"/ifs/data\",\"permissions\":[{\"permission\":\"full\",\"permission_type\":\"allow\",\"trustee\":{\"id\":\"SID:S-1-1-0\",\"name\":\"Everyone\",\"type\":\"wellknown\"}}]}\n"
time="2023-07-10T03:09:06-04:00" level=debug msg="\n    -------------------------- GOISILON HTTP RESPONSE -------------------------\n    HTTP/1.1 201 Created\n    Transfer-Encoding: chunked\n    Allow: GET, POST, DELETE, HEAD\n    Content-Security-Policy: default-src 'self' 'unsafe-inline' 'unsafe-eval' data:; script-src 'self' 'unsafe-eval'; style-src 'unsafe-inline' 'self';\n    Content-Type: application/json\n    Date: Mon, 10 Jul 2023 07:09:09 GMT\n    Location: /12/protocols/smb/shares/tf_share\n    Server: Apache\n    Strict-Transport-Security: max-age=31536000;\n    X-Content-Type-Options: nosniff\n    X-Frame-Options: sameorigin\n    X-Xss-Protection: 1; mode=block\n    "
time="2023-07-10T03:09:06-04:00" level=debug msg="\n    -------------------------- GOISILON HTTP REQUEST -------------------------\n    GET /platform/12/protocols/smb/shares/?limit=1 HTTP/1.1\n    Host: 10.230.24.241:8080\n    Authorization: root:******\n    \n"
time="2023-07-10T03:09:07-04:00" level=debug msg="\n    -------------------------- GOISILON HTTP RESPONSE -------------------------\n    HTTP/1.1 200 Ok\n    Transfer-Encoding: chunked\n    Allow: GET, POST, DELETE, HEAD\n    Content-Security-Policy: default-src 'self' 'unsafe-inline' 'unsafe-eval' data:; script-src 'self' 'unsafe-eval'; style-src 'unsafe-inline' 'self';\n    Content-Type: application/json\n    Date: Mon, 10 Jul 2023 07:09:09 GMT\n    Server: Apache\n    Strict-Transport-Security: max-age=31536000;\n    X-Content-Type-Options: nosniff\n    X-Frame-Options: sameorigin\n    X-Xss-Protection: 1; mode=block\n    "
time="2023-07-10T03:09:07-04:00" level=debug msg="\n    -------------------------- GOISILON HTTP REQUEST -------------------------\n    GET /platform/12/protocols/smb/shares/tf_share HTTP/1.1\n    Host: 10.230.24.241:8080\n    Authorization: root:******\n    \n"
time="2023-07-10T03:09:07-04:00" level=debug msg="\n    -------------------------- GOISILON HTTP RESPONSE -------------------------\n    HTTP/1.1 200 Ok\n    Transfer-Encoding: chunked\n    Allow: GET, PUT, DELETE, HEAD\n    Content-Security-Policy: default-src 'self' 'unsafe-inline' 'unsafe-eval' data:; script-src 'self' 'unsafe-eval'; style-src 'unsafe-inline' 'self';\n    Content-Type: application/json\n    Date: Mon, 10 Jul 2023 07:09:09 GMT\n    Server: Apache\n    Strict-Transport-Security: max-age=31536000;\n    X-Content-Type-Options: nosniff\n    X-Frame-Options: sameorigin\n    X-Xss-Protection: 1; mode=block\n    "
time="2023-07-10T03:09:07-04:00" level=debug msg="\n    -------------------------- GOISILON HTTP REQUEST -------------------------\n    PUT /platform/12/protocols/smb/shares/tf_share HTTP/1.1\n    Host: 10.230.24.241:8080\n    Authorization: root:******\n    Content-Type: application/json\n    \n    {\"ca_timeout\":112}\n"
time="2023-07-10T03:09:07-04:00" level=debug msg="\n    -------------------------- GOISILON HTTP RESPONSE -------------------------\n    HTTP/1.1 204 No Content\n    Content-Length: 0\n    Allow: GET, PUT, DELETE, HEAD\n    Content-Security-Policy: default-src 'self' 'unsafe-inline' 'unsafe-eval' data:; script-src 'self' 'unsafe-eval'; style-src 'unsafe-inline' 'self';\n    Date: Mon, 10 Jul 2023 07:09:09 GMT\n    Server: Apache\n    Strict-Transport-Security: max-age=31536000;\n    X-Content-Type-Options: nosniff\n    X-Frame-Options: sameorigin\n    X-Xss-Protection: 1; mode=block\n    "
time="2023-07-10T03:09:07-04:00" level=debug msg="\n    -------------------------- GOISILON HTTP REQUEST -------------------------\n    GET /platform/12/protocols/smb/shares/tf_share HTTP/1.1\n    Host: 10.230.24.241:8080\n    Authorization: root:******\n    \n"
time="2023-07-10T03:09:07-04:00" level=debug msg="\n    -------------------------- GOISILON HTTP RESPONSE -------------------------\n    HTTP/1.1 200 Ok\n    Transfer-Encoding: chunked\n    Allow: GET, PUT, DELETE, HEAD\n    Content-Security-Policy: default-src 'self' 'unsafe-inline' 'unsafe-eval' data:; script-src 'self' 'unsafe-eval'; style-src 'unsafe-inline' 'self';\n    Content-Type: application/json\n    Date: Mon, 10 Jul 2023 07:09:10 GMT\n    Server: Apache\n    Strict-Transport-Security: max-age=31536000;\n    X-Content-Type-Options: nosniff\n    X-Frame-Options: sameorigin\n    X-Xss-Protection: 1; mode=block\n    "
time="2023-07-10T03:09:07-04:00" level=debug msg="\n    -------------------------- GOISILON HTTP REQUEST -------------------------\n    DELETE /platform/12/protocols/smb/shares/tf_share HTTP/1.1\n    Host: 10.230.24.241:8080\n    Authorization: root:******\n    \n"
time="2023-07-10T03:09:08-04:00" level=debug msg="\n    -------------------------- GOISILON HTTP RESPONSE -------------------------\n    HTTP/1.1 204 No Content\n    Allow: GET, PUT, DELETE, HEAD\n    Content-Security-Policy: default-src 'self' 'unsafe-inline' 'unsafe-eval' data:; script-src 'self' 'unsafe-eval'; style-src 'unsafe-inline' 'self';\n    Date: Mon, 10 Jul 2023 07:09:10 GMT\n    Server: Apache\n    Strict-Transport-Security: max-age=31536000;\n    X-Content-Type-Options: nosniff\n    X-Frame-Options: sameorigin\n    X-Xss-Protection: 1; mode=block\n    "
time="2023-07-10T03:09:08-04:00" level=debug msg="\n    -------------------------- GOISILON HTTP REQUEST -------------------------\n    GET /platform/12/protocols/smb/shares/tf_share HTTP/1.1\n    Host: 10.230.24.241:8080\n    Authorization: root:******\n    \n"
time="2023-07-10T03:09:08-04:00" level=debug msg="\n    -------------------------- GOISILON HTTP RESPONSE -------------------------\n    HTTP/1.1 404 Not Found\n    Transfer-Encoding: chunked\n    Allow: GET, PUT, DELETE, HEAD\n    Content-Security-Policy: default-src 'self' 'unsafe-inline' 'unsafe-eval' data:; script-src 'self' 'unsafe-eval'; style-src 'unsafe-inline' 'self';\n    Content-Type: application/json\n    Date: Mon, 10 Jul 2023 07:09:10 GMT\n    Server: Apache\n    Strict-Transport-Security: max-age=31536000;\n    X-Content-Type-Options: nosniff\n    X-Frame-Options: sameorigin\n    X-Xss-Protection: 1; mode=block\n    "
**--- PASS: TestClient_SmbShareLifeCycleWithStructParams (1.42s)**
PASS
ok      github.com/dell/goisilon        5.266s


```

## Description of your changes:
<your change goes here>
