### PR TITLE
Implement Cluster API

### DIFF
--- a/api/v14/api_v14.go
+++ b/api/v14/api_v14.go
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2022 Dell Inc, or its subsidiaries.
+Copyright (c) 2023 Dell Inc, or its subsidiaries.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -13,21 +13,9 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
-package v3
 
-import (
-	"os"
-	"strconv"
-)
+package v14
 
 const (
-	namespacePath       = "namespace"
-	clusterConfigPath   = "platform/3/cluster/config"
-	clusterIdentityPath = "platform/3/cluster/identity"
-	clusterNodesPath    = "platform/3/cluster/nodes"
-)
-
-var (
-	debug, _   = strconv.ParseBool(os.Getenv("GOISILON_DEBUG"))
-	colonBytes = []byte{byte(':')}
+	clusterAcsPath = "platform/14/cluster/acs"
 )

--- a/api/v14/api_v14_cluster.go
+++ b/api/v14/api_v14_cluster.go
@@ -1,0 +1,22 @@
+package v14
+
+import (
+	"context"
+	"github.com/dell/goisilon/api"
+)
+
+// GetIsiClusterAcs queries ACS status of OneFS cluster
+func GetIsiClusterAcs(
+	ctx context.Context,
+	client api.Client) (clusterAcs *IsiClusterAcs, err error) {
+
+	// PAPI call: GET https://1.2.3.4:8080/platform/14/cluster/acs
+	// This will return ACS status.
+	var clusterAcsResp IsiClusterAcs
+	err = client.Get(ctx, clusterAcsPath, "", nil, nil, &clusterAcsResp)
+	if err != nil {
+		return nil, err
+	}
+
+	return &clusterAcsResp, nil
+}

--- a/api/v14/api_v14_types.go
+++ b/api/v14/api_v14_types.go
@@ -1,0 +1,33 @@
+/*
+Copyright (c) 2023 Dell Inc, or its subsidiaries.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v14
+
+// IsiClusterAcs Cluster ACS status.
+type IsiClusterAcs struct {
+	// list of failed nodes serial number.
+	FailedNodesSn []string `json:"failed_nodes_sn,omitempty"`
+	// the number of joined nodes.
+	JoinedNodes *int32 `json:"joined_nodes,omitempty"`
+	// the status of license activation.
+	LicenseStatus *string `json:"license_status,omitempty"`
+	// the status of SRS enablement.
+	SrsStatus *string `json:"srs_status,omitempty"`
+	// total nodes number of the cluster.
+	TotalNodes *int32 `json:"total_nodes,omitempty"`
+	// list of unresponsive nodes serial number.
+	UnresponsiveSn []string `json:"unresponsive_sn,omitempty"`
+}

--- a/api/v3/api_v3_cluster.go
+++ b/api/v3/api_v3_cluster.go
@@ -17,6 +17,7 @@ package v3
 
 import (
 	"context"
+	"fmt"
 	"strings"
 
 	"github.com/dell/goisilon/api"
@@ -97,4 +98,54 @@ func GetIsiClusterConfig(
 	}
 
 	return &clusterConfigResp, nil
+}
+
+// GetIsiClusterIdentity queries the config information of OneFS cluster
+func GetIsiClusterIdentity(
+	ctx context.Context,
+	client api.Client) (clusterConfig *IsiClusterIdentity, err error) {
+
+	// PAPI call: GET https://1.2.3.4:8080/platform/3/cluster/identity
+	// This will return the login information.
+	var clusterIdentityResp IsiClusterIdentity
+	err = client.Get(ctx, clusterIdentityPath, "", nil, nil, &clusterIdentityResp)
+	if err != nil {
+		return nil, err
+	}
+
+	return &clusterIdentityResp, nil
+}
+
+// GetIsiClusterNodes list the nodes on this cluster
+func GetIsiClusterNodes(
+	ctx context.Context,
+	client api.Client) (clusterNodes *IsiClusterNodes, err error) {
+
+	// PAPI call: GET https://1.2.3.4:8080/platform/3/cluster/nodes
+	// This will return list of the node information
+	var clusterNodesResp IsiClusterNodes
+	err = client.Get(ctx, clusterNodesPath, "", nil, nil, &clusterNodesResp)
+	if err != nil {
+		return nil, err
+	}
+
+	return &clusterNodesResp, nil
+}
+
+// GetIsiClusterNode retrieves the node information based on node ID
+func GetIsiClusterNode(
+	ctx context.Context,
+	client api.Client,
+	nodeID int) (clusterNodes *IsiClusterNodes, err error) {
+
+	// PAPI call: GET https://1.2.3.4:8080/platform/3/cluster/nodes/{v3ClusterNodeId}
+	// This will return list of the node information with only one node
+	var clusterNodesResp IsiClusterNodes
+	clusterNodePath := fmt.Sprintf("%s/%d", clusterNodesPath, nodeID)
+	err = client.Get(ctx, clusterNodePath, "", nil, nil, &clusterNodesResp)
+	if err != nil {
+		return nil, err
+	}
+
+	return &clusterNodesResp, nil
 }

--- a/api/v3/api_v3_types.go
+++ b/api/v3/api_v3_types.go
@@ -43,17 +43,45 @@ type IsiFloatStatsResp struct {
 	StatsList []*isiFloatStats `json:"stats"`
 }
 
+// IsiClusterConfigOnefsVersion struct for IsiClusterConfigOnefsVersion
+type IsiClusterConfigOnefsVersion struct {
+	// OneFS build string.
+	Build string `json:"build"`
+	// Kernel release number.
+	Release string `json:"release"`
+	// OneFS build number.
+	Revision string `json:"revision"`
+	// Kernel release type.
+	Type string `json:"type"`
+	// Kernel full version information.
+	Version string `json:"version"`
+}
+
+// IsiClusterConfigTimezone The cluster timezone settings.
+type IsiClusterConfigTimezone struct {
+	// Timezone abbreviation.
+	Abbreviation string `json:"abbreviation,omitempty"`
+	// Customer timezone information.
+	Custom string `json:"custom,omitempty"`
+	// Timezone full name.
+	Name string `json:"name,omitempty"`
+	// Timezone hierarchical name.
+	Path string `json:"path,omitempty"`
+}
+
 // IsiClusterConfig returns the configuration information of cluster.
 // TODO add other variables refers to the request cluster/config
 type IsiClusterConfig struct {
-	Description string       `json:"description"`
-	Devices     []*IsiDevice `json:"devices"`
-	GUID        string       `json:"guid"`
-	JoinMode    string       `json:"join_mode"`
-	LocalDevId  int64        `json:"local_devid"`
-	LocalLnn    int64        `json:"local_lnn"`
-	LocalSerial string       `json:"local_serial"`
-	Name        string       `json:"name"`
+	Description  string                        `json:"description"`
+	Devices      []*IsiDevice                  `json:"devices"`
+	GUID         string                        `json:"guid"`
+	JoinMode     string                        `json:"join_mode"`
+	LocalDevId   int64                         `json:"local_devid"`
+	LocalLnn     int64                         `json:"local_lnn"`
+	LocalSerial  string                        `json:"local_serial"`
+	Name         string                        `json:"name"`
+	OnefsVersion *IsiClusterConfigOnefsVersion `json:"onefs_version,omitempty"`
+	Timezone     *IsiClusterConfigTimezone     `json:"timezone,omitempty"`
 }
 
 // IsiDevice refers to device information of a cluster
@@ -71,4 +99,417 @@ type isiClientList struct {
 }
 type ExportClientList struct {
 	ClientsList []*isiClientList `json:"client"`
+}
+
+// IsiClusterIdentityLogon The information displayed when a user logs in to the cluster.
+type IsiClusterIdentityLogon struct {
+	// The message of the day.
+	Motd string `json:"motd"`
+	// The header to the message of the day.
+	MotdHeader string `json:"motd_header"`
+}
+
+// IsiClusterIdentity Unprivileged cluster information for display when logging in.
+type IsiClusterIdentity struct {
+	// A description of the cluster.
+	Description string                  `json:"description"`
+	Logon       IsiClusterIdentityLogon `json:"logon"`
+	// The name of the cluster.
+	Name string `json:"name"`
+}
+
+// IsiClusterNodes struct for IsiClusterNodes
+type IsiClusterNodes struct {
+	// A list of errors encountered by the individual nodes involved in this request, or an empty list if there were no errors.
+	Errors []IsiNodeStatusError `json:"errors,omitempty"`
+	// The responses from the individual nodes involved in this request.
+	Nodes []IsiClusterNode `json:"nodes,omitempty"`
+	// The total number of nodes responding.
+	Total *int32 `json:"total,omitempty"`
+}
+
+// IsiNodeStatusError An object describing a single error.
+type IsiNodeStatusError struct {
+	// The error code.
+	Code *string `json:"code,omitempty"`
+	// The field with the error if applicable.
+	Field *string `json:"field,omitempty"`
+	// Node ID (Device Number) of a node.
+	Id *int32 `json:"id,omitempty"`
+	// Logical Node Number (LNN) of a node.
+	Lnn *int32 `json:"lnn,omitempty"`
+	// The error message.
+	Message *string `json:"message,omitempty"`
+	// HTTP Status code returned by this node.
+	Status *int32 `json:"status,omitempty"`
+}
+
+// IsiClusterNode Node information.
+type IsiClusterNode struct {
+	// List of the drives in this node.
+	Drives []IsiClusterNodeDrive `json:"drives,omitempty"`
+	// Error message, if the HTTP status returned from this node was not 200.
+	Error    *string                 `json:"error,omitempty"`
+	Hardware *IsiClusterNodeHardware `json:"hardware,omitempty"`
+	// Node ID (Device Number) of a node.
+	Id *int32 `json:"id,omitempty"`
+	// Logical Node Number (LNN) of a node.
+	Lnn        *int32                    `json:"lnn,omitempty"`
+	Partitions *V10ClusterNodePartitions `json:"partitions,omitempty"`
+	Sensors    *IsiClusterNodeSensors    `json:"sensors,omitempty"`
+	State      *IsiClusterNodeState      `json:"state,omitempty"`
+	Status     *IsiClusterNodeStatus     `json:"status,omitempty"`
+}
+
+// IsiClusterNodeDrive Drive information.
+type IsiClusterNodeDrive struct {
+	// Numerical representation of this drive's bay.
+	Baynum *int32 `json:"baynum,omitempty"`
+	// Number of blocks on this drive.
+	Blocks *int32 `json:"blocks,omitempty"`
+	// The chassis number which contains this drive.
+	Chassis *int32 `json:"chassis,omitempty"`
+	// This drive's device name.
+	Devname  *string                      `json:"devname,omitempty"`
+	Firmware *IsiClusterNodeDriveFirmware `json:"firmware,omitempty"`
+	// Drive_d's handle representation for this driveIf we fail to retrieve the handle for this drive from drive_d: -1
+	Handle *int32 `json:"handle,omitempty"`
+	// String representation of this drive's interface type.
+	InterfaceType *string `json:"interface_type,omitempty"`
+	// This drive's logical drive number in IFS.
+	Lnum *int32 `json:"lnum,omitempty"`
+	// String representation of this drive's physical location.
+	Locnstr *string `json:"locnstr,omitempty"`
+	// Size of a logical block on this drive.
+	LogicalBlockLength *int32 `json:"logical_block_length,omitempty"`
+	// String representation of this drive's media type.
+	MediaType *string `json:"media_type,omitempty"`
+	// This drive's manufacturer and model.
+	Model *string `json:"model,omitempty"`
+	// Size of a physical block on this drive.
+	PhysicalBlockLength *int32 `json:"physical_block_length,omitempty"`
+	// Indicates whether this drive is physically present in the node.
+	Present *bool `json:"present,omitempty"`
+	// This drive's purpose in the DRV state machine.
+	Purpose *string `json:"purpose,omitempty"`
+	// Description of this drive's purpose.
+	PurposeDescription *string `json:"purpose_description,omitempty"`
+	// Serial number for this drive.
+	Serial *string `json:"serial,omitempty"`
+	// This drive's state as presented to the UI.
+	UiState *string `json:"ui_state,omitempty"`
+	// The drive's 'worldwide name' from its NAA identifiers.
+	Wwn *string `json:"wwn,omitempty"`
+	// This drive's x-axis grid location.
+	XLoc *int32 `json:"x_loc,omitempty"`
+	// This drive's y-axis grid location.
+	YLoc *int32 `json:"y_loc,omitempty"`
+}
+
+// IsiClusterNodeDriveFirmware Drive firmware information.
+type IsiClusterNodeDriveFirmware struct {
+	// This drive's current firmware revision
+	CurrentFirmware *string `json:"current_firmware,omitempty"`
+	// This drive's desired firmware revision.
+	DesiredFirmware *string `json:"desired_firmware,omitempty"`
+}
+
+// IsiClusterNodeHardware Node hardware identifying information (static).
+type IsiClusterNodeHardware struct {
+	// Name of this node's chassis.
+	Chassis *string `json:"chassis,omitempty"`
+	// Chassis code of this node (1U, 2U, etc.).
+	ChassisCode *string `json:"chassis_code,omitempty"`
+	// Number of chassis making up this node.
+	ChassisCount *string `json:"chassis_count,omitempty"`
+	// Class of this node (storage, accelerator, etc.).
+	Class *string `json:"class,omitempty"`
+	// Node configuration ID.
+	ConfigurationId *string `json:"configuration_id,omitempty"`
+	// Manufacturer and model of this node's CPU.
+	Cpu *string `json:"cpu,omitempty"`
+	// Manufacturer and model of this node's disk controller.
+	DiskController *string `json:"disk_controller,omitempty"`
+	// Manufacturer and model of this node's disk expander.
+	DiskExpander *string `json:"disk_expander,omitempty"`
+	// Family code of this node (X, S, NL, etc.).
+	FamilyCode *string `json:"family_code,omitempty"`
+	// Manufacturer, model, and device id of this node's flash drive.
+	FlashDrive *string `json:"flash_drive,omitempty"`
+	// Generation code of this node.
+	GenerationCode *string `json:"generation_code,omitempty"`
+	// PowerScale hardware generation name.
+	Hwgen *string `json:"hwgen,omitempty"`
+	// Version of this node's PowerScale Management Board.
+	ImbVersion *string `json:"imb_version,omitempty"`
+	// Infiniband card type.
+	Infiniband *string `json:"infiniband,omitempty"`
+	// Version of the LCD panel.
+	LcdVersion *string `json:"lcd_version,omitempty"`
+	// Manufacturer and model of this node's motherboard.
+	Motherboard *string `json:"motherboard,omitempty"`
+	// Description of all this node's network interfaces.
+	NetInterfaces *string `json:"net_interfaces,omitempty"`
+	// Manufacturer and model of this node's NVRAM board.
+	Nvram *string `json:"nvram,omitempty"`
+	// Description strings for each power supply on this node.
+	Powersupplies []string `json:"powersupplies,omitempty"`
+	// Number of processors and cores on this node.
+	Processor *string `json:"processor,omitempty"`
+	// PowerScale product name.
+	Product *string `json:"product,omitempty"`
+	// Size of RAM in bytes.
+	Ram *int64 `json:"ram,omitempty"`
+	// Serial number of this node.
+	SerialNumber *string `json:"serial_number,omitempty"`
+	// Series of this node (X, I, NL, etc.).
+	Series *string `json:"series,omitempty"`
+	// Storage class of this node (storage or diskless).
+	StorageClass *string `json:"storage_class,omitempty"`
+}
+
+// IsiClusterNodeState Node state information (reported and modifiable).
+type IsiClusterNodeState struct {
+	Readonly     map[string]interface{}           `json:"readonly,omitempty"`
+	Servicelight *IsiClusterNodeStateServicelight `json:"servicelight,omitempty"`
+	Smartfail    *IsiClusterNodeStateSmartfail    `json:"smartfail,omitempty"`
+}
+
+// IsiClusterNodeStateServicelight Node service light state.
+type IsiClusterNodeStateServicelight struct {
+	// The node service light state (True = on).
+	Enabled bool `json:"enabled"`
+}
+
+// IsiClusterNodeStateSmartfail Node smartfail state.
+type IsiClusterNodeStateSmartfail struct {
+	// This node is smartfailed (soft_devs).
+	Smartfailed *bool `json:"smartfailed,omitempty"`
+}
+
+// V10ClusterNodePartitions Node partition information.
+type V10ClusterNodePartitions struct {
+	// Count of how many partitions are included.
+	Count *int32 `json:"count,omitempty"`
+	// Partition information.
+	Partitions []IsiClusterNodePartition `json:"partitions,omitempty"`
+}
+
+// IsiClusterNodePartition Node partition information.
+type IsiClusterNodePartition struct {
+	// The block size used for the reported partition information.
+	BlockSize *int32 `json:"block_size,omitempty"`
+	// Total blocks on this file system partition.
+	Capacity *int32 `json:"capacity,omitempty"`
+	// Comma separated list of devices used for this file system partition.
+	ComponentDevices *string `json:"component_devices,omitempty"`
+	// Directory on which this partition is mounted.
+	MountPoint *string `json:"mount_point,omitempty"`
+	// Used blocks on this file system partition, expressed as a percentage.
+	PercentUsed *string                        `json:"percent_used,omitempty"`
+	Statfs      *IsiClusterNodePartitionStatfs `json:"statfs,omitempty"`
+	// Used blocks on this file system partition.
+	Used *int32 `json:"used,omitempty"`
+}
+
+// IsiClusterNodePartitionStatfs System partition details as provided by statfs(2).
+type IsiClusterNodePartitionStatfs struct {
+	// Free blocks available to non-superuser on this partition.
+	FBavail *int32 `json:"f_bavail,omitempty"`
+	// Free blocks on this partition.
+	FBfree *int32 `json:"f_bfree,omitempty"`
+	// Total data blocks on this partition.
+	FBlocks *int32 `json:"f_blocks,omitempty"`
+	// Filesystem fragment size; block size in OneFS.
+	FBsize *int32 `json:"f_bsize,omitempty"`
+	// Free file nodes avail to non-superuser.
+	FFfree *int32 `json:"f_ffree,omitempty"`
+	// Total file nodes in filesystem.
+	FFiles *int32 `json:"f_files,omitempty"`
+	// Mount exported flags.
+	FFlags *int32 `json:"f_flags,omitempty"`
+	// File system type name.
+	FFstypename *string `json:"f_fstypename,omitempty"`
+	// Optimal transfer block size.
+	FIosize *int32 `json:"f_iosize,omitempty"`
+	// Names of devices this partition is mounted from.
+	FMntfromname *string `json:"f_mntfromname,omitempty"`
+	// Directory this partition is mounted to.
+	FMntonname *string `json:"f_mntonname,omitempty"`
+	// Maximum filename length.
+	FNamemax *int32 `json:"f_namemax,omitempty"`
+	// UID of user that mounted the filesystem.
+	FOwner *int32 `json:"f_owner,omitempty"`
+	// Type of filesystem.
+	FType *int32 `json:"f_type,omitempty"`
+	// statfs() structure version number.
+	FVersion *int32 `json:"f_version,omitempty"`
+}
+
+// IsiClusterNodeSensors Node sensor information (hardware reported).
+type IsiClusterNodeSensors struct {
+	// This node's sensor information.
+	Sensors []IsiClusterNodeSensor `json:"sensors,omitempty"`
+}
+
+// IsiClusterNodeSensor Node sensor information.
+type IsiClusterNodeSensor struct {
+	// The count of values in this sensor group.
+	Count *int32 `json:"count,omitempty"`
+	// The name of this sensor group.
+	Name *string `json:"name,omitempty"`
+	// The list of specific sensor value info in this sensor group.
+	Values []IsiClusterNodeSensorValue `json:"values,omitempty"`
+}
+
+// IsiClusterNodeSensorValue Specific sensor value info.
+type IsiClusterNodeSensorValue struct {
+	// The descriptive name of this sensor.
+	Desc *string `json:"desc,omitempty"`
+	// The identifier name of this sensor.
+	Name *string `json:"name,omitempty"`
+	// The units of this sensor.
+	Units *string `json:"units,omitempty"`
+	// The value of this sensor.
+	Value *string `json:"value,omitempty"`
+}
+
+// IsiClusterNodeStatus Node status information (hardware reported).
+type IsiClusterNodeStatus struct {
+	Batterystatus *IsiClusterNodeStatusBatterystatus `json:"batterystatus,omitempty"`
+	// Storage capacity of this node.
+	Capacity      []IsiClusterNodeStatusCapacityItem `json:"capacity,omitempty"`
+	Cpu           *IsiClusterNodeStatusCpu           `json:"cpu,omitempty"`
+	Nvram         *IsiClusterNodeStatusNvram         `json:"nvram,omitempty"`
+	Powersupplies *IsiClusterNodeStatusPowersupplies `json:"powersupplies,omitempty"`
+	// OneFS release.
+	Release *string `json:"release,omitempty"`
+	// Seconds this node has been online.
+	Uptime *int32 `json:"uptime,omitempty"`
+	// OneFS version.
+	Version *string `json:"version,omitempty"`
+}
+
+// IsiClusterNodeStatusBatterystatus Battery status information.
+type IsiClusterNodeStatusBatterystatus struct {
+	// The last battery test time for battery 1.
+	LastTestTime1 *string `json:"last_test_time1,omitempty"`
+	// The last battery test time for battery 2.
+	LastTestTime2 *string `json:"last_test_time2,omitempty"`
+	// The next checkup for battery 1.
+	NextTestTime1 *string `json:"next_test_time1,omitempty"`
+	// The next checkup for battery 2.
+	NextTestTime2 *string `json:"next_test_time2,omitempty"`
+	// Node has battery status.
+	Present *bool `json:"present,omitempty"`
+	// The result of the last battery test for battery 1.
+	Result1 *string `json:"result1,omitempty"`
+	// The result of the last battery test for battery 2.
+	Result2 *string `json:"result2,omitempty"`
+	// The status of battery 1.
+	Status1 *string `json:"status1,omitempty"`
+	// The status of battery 2.
+	Status2 *string `json:"status2,omitempty"`
+	// Node supports battery status.
+	Supported *bool `json:"supported,omitempty"`
+}
+
+// IsiClusterNodeStatusCapacityItem Node capacity information.
+type IsiClusterNodeStatusCapacityItem struct {
+	// Total device storage bytes.
+	Bytes *int64 `json:"bytes,omitempty"`
+	// Total device count.
+	Count *int32 `json:"count,omitempty"`
+	// Device type.
+	Type *string `json:"type,omitempty"`
+}
+
+// IsiClusterNodeStatusCpu CPU status information for this node.
+type IsiClusterNodeStatusCpu struct {
+	// Manufacturer model description of this CPU.
+	Model *string `json:"model,omitempty"`
+	// CPU overtemp state.
+	Overtemp *string `json:"overtemp,omitempty"`
+	// Type of processor and core of this CPU.
+	Proc *string `json:"proc,omitempty"`
+	// CPU throttling (expressed as a percentage).
+	SpeedLimit *string `json:"speed_limit,omitempty"`
+}
+
+// IsiClusterNodeStatusNvram Node NVRAM information.
+type IsiClusterNodeStatusNvram struct {
+	// This node's NVRAM battery status information.
+	Batteries []IsiClusterNodeStatusNvramBattery `json:"batteries,omitempty"`
+	// This node's NVRAM battery count. On failure: -1, otherwise 1 or 2.
+	BatteryCount *int32 `json:"battery_count,omitempty"`
+	// This node's NVRAM battery charge status, as a color.
+	ChargeStatus *string `json:"charge_status,omitempty"`
+	// This node's NVRAM battery charge status, as a number. Error or not supported: -1. BR_BLACK: 0. BR_GREEN: 1. BR_YELLOW: 2. BR_RED: 3.
+	ChargeStatusNumber *int32 `json:"charge_status_number,omitempty"`
+	// This node's NVRAM device name with path.
+	Device *string `json:"device,omitempty"`
+	// This node has NVRAM.
+	Present *bool `json:"present,omitempty"`
+	// This node has NVRAM with flash storage.
+	PresentFlash *bool `json:"present_flash,omitempty"`
+	// The size of the NVRAM, in bytes.
+	PresentSize *int32 `json:"present_size,omitempty"`
+	// This node's NVRAM type.
+	PresentType *string `json:"present_type,omitempty"`
+	// This node's current ship mode state for NVRAM batteries. If not supported or on failure: -1. Disabled: 0. Enabled: 1.
+	ShipMode *int32 `json:"ship_mode,omitempty"`
+	// This node supports NVRAM.
+	Supported *bool `json:"supported,omitempty"`
+	// This node supports NVRAM with flash storage.
+	SupportedFlash *bool `json:"supported_flash,omitempty"`
+	// The maximum size of the NVRAM, in bytes.
+	SupportedSize *int64 `json:"supported_size,omitempty"`
+	// This node's supported NVRAM type.
+	SupportedType *string `json:"supported_type,omitempty"`
+}
+
+// IsiClusterNodeStatusNvramBattery NVRAM battery status information.
+type IsiClusterNodeStatusNvramBattery struct {
+	// The current status color of the NVRAM battery.
+	Color *string `json:"color,omitempty"`
+	// Identifying index for the NVRAM battery.
+	Id *int32 `json:"id,omitempty"`
+	// The current status message of the NVRAM battery.
+	Status *string `json:"status,omitempty"`
+	// The current voltage of the NVRAM battery.
+	Voltage *string `json:"voltage,omitempty"`
+}
+
+// IsiClusterNodeStatusPowersupplies Information about this node's power supplies.
+type IsiClusterNodeStatusPowersupplies struct {
+	// Count of how many power supplies are supported.
+	Count *int32 `json:"count,omitempty"`
+	// Count of how many power supplies have failed.
+	Failures *int32 `json:"failures,omitempty"`
+	// Does this node have a CFF power supply.
+	HasCff *bool `json:"has_cff,omitempty"`
+	// A descriptive status string for this node's power supplies.
+	Status *string `json:"status,omitempty"`
+	// List of this node's power supplies.
+	Supplies []IsiClusterNodeStatusPowersuppliesSupply `json:"supplies,omitempty"`
+	// Does this node support CFF power supplies.
+	SupportsCff *bool `json:"supports_cff,omitempty"`
+}
+
+// IsiClusterNodeStatusPowersuppliesSupply Power supply information.
+type IsiClusterNodeStatusPowersuppliesSupply struct {
+	// Which node chassis is this power supply in.
+	Chassis *int32 `json:"chassis,omitempty"`
+	// The current firmware revision of this power supply.
+	Firmware *string `json:"firmware,omitempty"`
+	// Is this power supply in a failure state.
+	Good *string `json:"good,omitempty"`
+	// Identifying index for this power supply.
+	Id int32 `json:"id"`
+	// Complete identifying string for this power supply.
+	Name *string `json:"name,omitempty"`
+	// A descriptive status string for this power supply.
+	Status *string `json:"status,omitempty"`
+	// The type of this power supply.
+	Type *string `json:"type,omitempty"`
 }

--- a/api/v7/api_v7.go
+++ b/api/v7/api_v7.go
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2022 Dell Inc, or its subsidiaries.
+Copyright (c) 2023 Dell Inc, or its subsidiaries.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -13,21 +13,9 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
-package v3
 
-import (
-	"os"
-	"strconv"
-)
+package v7
 
 const (
-	namespacePath       = "namespace"
-	clusterConfigPath   = "platform/3/cluster/config"
-	clusterIdentityPath = "platform/3/cluster/identity"
-	clusterNodesPath    = "platform/3/cluster/nodes"
-)
-
-var (
-	debug, _   = strconv.ParseBool(os.Getenv("GOISILON_DEBUG"))
-	colonBytes = []byte{byte(':')}
+	clusterInternalNetworksPath = "platform/7/cluster/internal-networks"
 )

--- a/api/v7/api_v7_cluster.go
+++ b/api/v7/api_v7_cluster.go
@@ -1,0 +1,22 @@
+package v7
+
+import (
+	"context"
+	"github.com/dell/goisilon/api"
+)
+
+// GetIsiClusterInternalNetworks queries internal networks settings
+func GetIsiClusterInternalNetworks(
+	ctx context.Context,
+	client api.Client) (clusterInternalNetworks *IsiClusterInternalNetworks, err error) {
+
+	// PAPI call: GET https://1.2.3.4:8080/platform/7/cluster/internal-networks
+	// This will return the internal networks settings
+	var clusterInternalNetworksResp IsiClusterInternalNetworks
+	err = client.Get(ctx, clusterInternalNetworksPath, "", nil, nil, &clusterInternalNetworksResp)
+	if err != nil {
+		return nil, err
+	}
+
+	return &clusterInternalNetworksResp, nil
+}

--- a/api/v7/api_v7_types.go
+++ b/api/v7/api_v7_types.go
@@ -1,0 +1,51 @@
+/*
+Copyright (c) 2023 Dell Inc, or its subsidiaries.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v7
+
+// IsiClusterInternalNetworksFailoverIpAddresse Specifies range of IP addresses where 'low' is starting address and 'high' is the end address.' Both 'low' and 'high' addresses are inclusive to the range.
+type IsiClusterInternalNetworksFailoverIpAddresse struct {
+	// IPv4 address in the format: xxx.xxx.xxx.xxx
+	High string `json:"high"`
+	// IPv4 address in the format: xxx.xxx.xxx.xxx
+	Low string `json:"low"`
+}
+
+// IsiClusterInternalNetworks Configuration fields for internal networks.
+type IsiClusterInternalNetworks struct {
+	// Array of IP address ranges to be used to configure the internal failover network of the OneFS cluster.
+	FailoverIpAddresses []IsiClusterInternalNetworksFailoverIpAddresse `json:"failover_ip_addresses,omitempty"`
+	// Status of failover network.
+	FailoverStatus *string `json:"failover_status,omitempty"`
+	// Network fabric used for the primary network int-a.
+	IntAFabric *string `json:"int_a_fabric,omitempty"`
+	// Array of IP address ranges to be used to configure the internal int-a network of the OneFS cluster.
+	IntAIpAddresses []IsiClusterInternalNetworksFailoverIpAddresse `json:"int_a_ip_addresses,omitempty"`
+	// Maximum Transfer Unit (MTU) of the primary network int-a.
+	IntAMtu *int32 `json:"int_a_mtu,omitempty"`
+	// Prefixlen specifies the length of network bits used in an IP address. This field is the right-hand part of the CIDR notation representing the subnet mask.
+	IntAPrefixLength *int32 `json:"int_a_prefix_length,omitempty"`
+	// Status of the primary network int-a.
+	IntAStatus *string `json:"int_a_status,omitempty"`
+	// Network fabric used for the failover network.
+	IntBFabric *string `json:"int_b_fabric,omitempty"`
+	// Array of IP address ranges to be used to configure the internal int-b network of the OneFS cluster.
+	IntBIpAddresses []IsiClusterInternalNetworksFailoverIpAddresse `json:"int_b_ip_addresses,omitempty"`
+	// Maximum Transfer Unit (MTU) of the failover network int-b.
+	IntBMtu *int32 `json:"int_b_mtu,omitempty"`
+	// Prefixlen specifies the length of network bits used in an IP address. This field is the right-hand part of the CIDR notation representing the subnet mask.
+	IntBPrefixLength *int32 `json:"int_b_prefix_length,omitempty"`
+}

--- a/cluster.go
+++ b/cluster.go
@@ -18,13 +18,22 @@ package goisilon
 import (
 	"context"
 
+	apiv14 "github.com/dell/goisilon/api/v14"
 	apiv3 "github.com/dell/goisilon/api/v3"
+	apiv7 "github.com/dell/goisilon/api/v7"
 )
 
 // Stats is Isilon statistics data structure .
 type Stats *apiv3.IsiStatsResp
 type FloatStats *apiv3.IsiFloatStatsResp
 type Clients *apiv3.ExportClientList
+
+// ClusterConfig represents the configuration of cluster in k8s (namespace API).
+type ClusterConfig *apiv3.IsiClusterConfig
+type ClusterIdentity *apiv3.IsiClusterIdentity
+type ClusterNodes *apiv3.IsiClusterNodes
+type ClusterAcs *apiv14.IsiClusterAcs
+type ClusterInternalNetworks *apiv7.IsiClusterInternalNetworks
 
 // GetStatistics returns statistics from Isilon. Keys indicate type of statistics expected
 func (c *Client) GetStatistics(
@@ -64,9 +73,6 @@ func (c *Client) IsIOInProgress(
 	return clientList, nil
 }
 
-// ClusterConfig represents the configuration of cluster in k8s (namespace API).
-type ClusterConfig *apiv3.IsiClusterConfig
-
 // GetClusterConfig returns information about the configuration of cluster
 func (c *Client) GetClusterConfig(ctx context.Context) (ClusterConfig, error) {
 	clusterConfig, err := apiv3.GetIsiClusterConfig(ctx, c.API)
@@ -74,6 +80,51 @@ func (c *Client) GetClusterConfig(ctx context.Context) (ClusterConfig, error) {
 		return nil, err
 	}
 	return clusterConfig, nil
+}
+
+// GetClusterIdentity returns the login information
+func (c *Client) GetClusterIdentity(ctx context.Context) (ClusterIdentity, error) {
+	clusterIdentity, err := apiv3.GetIsiClusterIdentity(ctx, c.API)
+	if err != nil {
+		return nil, err
+	}
+	return clusterIdentity, nil
+}
+
+// GetClusterAcs returns the ACS status
+func (c *Client) GetClusterAcs(ctx context.Context) (ClusterAcs, error) {
+	clusterAcs, err := apiv14.GetIsiClusterAcs(ctx, c.API)
+	if err != nil {
+		return nil, err
+	}
+	return clusterAcs, nil
+}
+
+// GetClusterInternalNetworks internal networks settings
+func (c *Client) GetClusterInternalNetworks(ctx context.Context) (ClusterInternalNetworks, error) {
+	clusterInternalNetworks, err := apiv7.GetIsiClusterInternalNetworks(ctx, c.API)
+	if err != nil {
+		return nil, err
+	}
+	return clusterInternalNetworks, nil
+}
+
+// GetClusterNodes list the nodes on this cluster
+func (c *Client) GetClusterNodes(ctx context.Context) (ClusterNodes, error) {
+	clusterNodes, err := apiv3.GetIsiClusterNodes(ctx, c.API)
+	if err != nil {
+		return nil, err
+	}
+	return clusterNodes, nil
+}
+
+// GetClusterNode retrieves one node on this cluster
+func (c *Client) GetClusterNode(ctx context.Context, nodeID int) (ClusterNodes, error) {
+	clusterNodes, err := apiv3.GetIsiClusterNode(ctx, c.API, nodeID)
+	if err != nil {
+		return nil, err
+	}
+	return clusterNodes, nil
 }
 
 // GetLocalSerial returns the local serial which is the serial number of cluster

--- a/cluster_test.go
+++ b/cluster_test.go
@@ -15,7 +15,9 @@ limitations under the License.
 */
 package goisilon
 
-import "testing"
+import (
+	"testing"
+)
 
 func TestGetStatistics(*testing.T) {
 	keyArray := []string{"ifs.bytes.avail", "ifs.bytes.total"}
@@ -48,4 +50,46 @@ func TestGetLocalSerial(t *testing.T) {
 	}
 	println(localSerial)
 
+}
+
+func TestGetClusterConfig(t *testing.T) {
+	config, err := client.GetClusterConfig(defaultCtx)
+	assertNoError(t, err)
+	assertNotNil(t, config.OnefsVersion)
+	assertNotNil(t, config.Timezone)
+}
+
+func TestGetClusterIdentity(t *testing.T) {
+	identity, err := client.GetClusterIdentity(defaultCtx)
+	assertNoError(t, err)
+	assertNotNil(t, identity)
+	assertNotNil(t, identity.Name)
+}
+
+func TestGetClusterAcs(t *testing.T) {
+	acs, err := client.GetClusterAcs(defaultCtx)
+	assertNoError(t, err)
+	assertNotNil(t, acs)
+}
+
+func TestGetClusterInternalNetworks(t *testing.T) {
+	networks, err := client.GetClusterInternalNetworks(defaultCtx)
+	assertNoError(t, err)
+	assertNotNil(t, networks)
+}
+
+func TestGetClusterNodes(t *testing.T) {
+	nodes, err := client.GetClusterNodes(defaultCtx)
+	assertNoError(t, err)
+	assertNotNil(t, nodes)
+	assertNotEqual(t, int(*nodes.Total), 0)
+}
+
+func TestGetClusterNode(t *testing.T) {
+	var nodeID = 1
+	nodes, err := client.GetClusterNode(defaultCtx, nodeID)
+	assertNoError(t, err)
+	assertNotNil(t, nodes)
+	assertEqual(t, int(*nodes.Total), 1)
+	assertLen(t, nodes.Nodes, 1)
 }


### PR DESCRIPTION
# PR Submission checklist

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
|https://github.com/dell/csm/issues/888|

# Common PR Checklist:

- [x] Have you made sure that the code compiles?
- [x] Have you commented your code, particularly in hard-to-understand areas
- [ ] Did you run tests in a real Kubernetes cluster?
- [x] Have you maintained backward compatibility


## Tests

```
time="2023-07-13T13:48:16+08:00" level=debug msg="opts.Insecure : 'true'"
time="2023-07-13T13:48:16+08:00" level=debug msg="\n    -------------------------- GOISILON HTTP REQUEST -------------------------\n    GET /platform/latest/ HTTP/1.1\n    Host: 10.225.108.6:8080\n    Authorization: root:******\n    \n"
time="2023-07-13T13:48:17+08:00" level=debug msg="\n    -------------------------- GOISILON HTTP RESPONSE -------------------------\n    HTTP/1.1 200 Ok\n    Transfer-Encoding: chunked\n    Content-Security-Policy: default-src 'self' 'unsafe-inline' 'unsafe-eval' data:; script-src 'self' 'unsafe-eval'; style-src 'unsafe-inline' 'self';\n    Content-Type: application/json\n    Date: Thu, 13 Jul 2023 04:28:04 GMT\n    Server: Apache\n    Strict-Transport-Security: max-age=31536000;\n    X-Content-Type-Options: nosniff\n    X-Frame-Options: sameorigin\n    X-Xss-Protection: 1; mode=block\n    "
=== RUN   TestGetStatistics
time="2023-07-13T13:48:17+08:00" level=debug msg="\n    -------------------------- GOISILON HTTP REQUEST -------------------------\n    GET /platform/3/statistics/current?keys=ifs.bytes.avail%!C(MISSING)ifs.bytes.total HTTP/1.1\n    Host: 10.225.108.6:8080\n    Authorization: root:******\n    \n"
time="2023-07-13T13:48:18+08:00" level=debug msg="\n    -------------------------- GOISILON HTTP RESPONSE -------------------------\n    HTTP/1.1 200 Ok\n    Transfer-Encoding: chunked\n    Allow: GET, HEAD\n    Content-Security-Policy: default-src 'self' 'unsafe-inline' 'unsafe-eval' data:; script-src 'self' 'unsafe-eval'; style-src 'unsafe-inline' 'self';\n    Content-Type: application/json\n    Date: Thu, 13 Jul 2023 04:28:05 GMT\n    Server: Apache\n    Strict-Transport-Security: max-age=31536000;\n    X-Content-Type-Options: nosniff\n    X-Frame-Options: sameorigin\n    X-Xss-Protection: 1; mode=block\n    "
--- PASS: TestGetStatistics (1.02s)
=== RUN   TestGetFloatStatistics
time="2023-07-13T13:48:18+08:00" level=debug msg="\n    -------------------------- GOISILON HTTP REQUEST -------------------------\n    GET /platform/3/statistics/current?keys=cluster.disk.bytes.in.rate%!C(MISSING)ifs.bytes.total%!C(MISSING)cluster.disk.xfers.in.rate HTTP/1.1\n    Host: 10.225.108.6:8080\n    Authorization: root:******\n    \n"
time="2023-07-13T13:48:19+08:00" level=debug msg="\n    -------------------------- GOISILON HTTP RESPONSE -------------------------\n    HTTP/1.1 200 Ok\n    Transfer-Encoding: chunked\n    Allow: GET, HEAD\n    Content-Security-Policy: default-src 'self' 'unsafe-inline' 'unsafe-eval' data:; script-src 'self' 'unsafe-eval'; style-src 'unsafe-inline' 'self';\n    Content-Type: application/json\n    Date: Thu, 13 Jul 2023 04:28:06 GMT\n    Server: Apache\n    Strict-Transport-Security: max-age=31536000;\n    X-Content-Type-Options: nosniff\n    X-Frame-Options: sameorigin\n    X-Xss-Protection: 1; mode=block\n    "
--- PASS: TestGetFloatStatistics (1.06s)
=== RUN   TestGetLocalSerial
time="2023-07-13T13:48:19+08:00" level=debug msg="\n    -------------------------- GOISILON HTTP REQUEST -------------------------\n    GET /platform/3/cluster/config/ HTTP/1.1\n    Host: 10.225.108.6:8080\n    Authorization: root:******\n    \n"
time="2023-07-13T13:48:20+08:00" level=debug msg="\n    -------------------------- GOISILON HTTP RESPONSE -------------------------\n    HTTP/1.1 200 Ok\n    Transfer-Encoding: chunked\n    Allow: GET, HEAD\n    Content-Security-Policy: default-src 'self' 'unsafe-inline' 'unsafe-eval' data:; script-src 'self' 'unsafe-eval'; style-src 'unsafe-inline' 'self';\n    Content-Type: application/json\n    Date: Thu, 13 Jul 2023 04:28:07 GMT\n    Server: Apache\n    Strict-Transport-Security: max-age=31536000;\n    X-Content-Type-Options: nosniff\n    X-Frame-Options: sameorigin\n    X-Xss-Protection: 1; mode=block\n    "
SV200-004EIH-G7ON
--- PASS: TestGetLocalSerial (1.08s)
=== RUN   TestGetClusterConfig
time="2023-07-13T13:48:20+08:00" level=debug msg="\n    -------------------------- GOISILON HTTP REQUEST -------------------------\n    GET /platform/3/cluster/config/ HTTP/1.1\n    Host: 10.225.108.6:8080\n    Authorization: root:******\n    \n"
time="2023-07-13T13:48:22+08:00" level=debug msg="\n    -------------------------- GOISILON HTTP RESPONSE -------------------------\n    HTTP/1.1 200 Ok\n    Transfer-Encoding: chunked\n    Allow: GET, HEAD\n    Content-Security-Policy: default-src 'self' 'unsafe-inline' 'unsafe-eval' data:; script-src 'self' 'unsafe-eval'; style-src 'unsafe-inline' 'self';\n    Content-Type: application/json\n    Date: Thu, 13 Jul 2023 04:28:08 GMT\n    Server: Apache\n    Strict-Transport-Security: max-age=31536000;\n    X-Content-Type-Options: nosniff\n    X-Frame-Options: sameorigin\n    X-Xss-Protection: 1; mode=block\n    "
--- PASS: TestGetClusterConfig (1.04s)
=== RUN   TestGetClusterIdentity
time="2023-07-13T13:48:22+08:00" level=debug msg="\n    -------------------------- GOISILON HTTP REQUEST -------------------------\n    GET /platform/3/cluster/identity/ HTTP/1.1\n    Host: 10.225.108.6:8080\n    Authorization: root:******\n    \n"
time="2023-07-13T13:48:23+08:00" level=debug msg="\n    -------------------------- GOISILON HTTP RESPONSE -------------------------\n    HTTP/1.1 200 Ok\n    Transfer-Encoding: chunked\n    Allow: GET, PUT, HEAD\n    Content-Security-Policy: default-src 'self' 'unsafe-inline' 'unsafe-eval' data:; script-src 'self' 'unsafe-eval'; style-src 'unsafe-inline' 'self';\n    Content-Type: application/json\n    Date: Thu, 13 Jul 2023 04:28:09 GMT\n    Server: Apache\n    Strict-Transport-Security: max-age=31536000;\n    X-Content-Type-Options: nosniff\n    X-Frame-Options: sameorigin\n    X-Xss-Protection: 1; mode=block\n    "
--- PASS: TestGetClusterIdentity (1.04s)
=== RUN   TestGetClusterAcs
time="2023-07-13T13:48:23+08:00" level=debug msg="\n    -------------------------- GOISILON HTTP REQUEST -------------------------\n    GET /platform/14/cluster/acs/ HTTP/1.1\n    Host: 10.225.108.6:8080\n    Authorization: root:******\n    \n"
time="2023-07-13T13:48:24+08:00" level=debug msg="\n    -------------------------- GOISILON HTTP RESPONSE -------------------------\n    HTTP/1.1 200 Ok\n    Transfer-Encoding: chunked\n    Allow: GET, POST, HEAD\n    Content-Security-Policy: default-src 'self' 'unsafe-inline' 'unsafe-eval' data:; script-src 'self' 'unsafe-eval'; style-src 'unsafe-inline' 'self';\n    Content-Type: application/json\n    Date: Thu, 13 Jul 2023 04:28:10 GMT\n    Server: Apache\n    Strict-Transport-Security: max-age=31536000;\n    X-Content-Type-Options: nosniff\n    X-Frame-Options: sameorigin\n    X-Xss-Protection: 1; mode=block\n    "
--- PASS: TestGetClusterAcs (1.01s)
=== RUN   TestGetClusterInternalNetworks
time="2023-07-13T13:48:24+08:00" level=debug msg="\n    -------------------------- GOISILON HTTP REQUEST -------------------------\n    GET /platform/7/cluster/internal-networks/ HTTP/1.1\n    Host: 10.225.108.6:8080\n    Authorization: root:******\n    \n"
time="2023-07-13T13:48:25+08:00" level=debug msg="\n    -------------------------- GOISILON HTTP RESPONSE -------------------------\n    HTTP/1.1 200 Ok\n    Transfer-Encoding: chunked\n    Allow: GET, PUT, HEAD\n    Content-Security-Policy: default-src 'self' 'unsafe-inline' 'unsafe-eval' data:; script-src 'self' 'unsafe-eval'; style-src 'unsafe-inline' 'self';\n    Content-Type: application/json\n    Date: Thu, 13 Jul 2023 04:28:11 GMT\n    Server: Apache\n    Strict-Transport-Security: max-age=31536000;\n    X-Content-Type-Options: nosniff\n    X-Frame-Options: sameorigin\n    X-Xss-Protection: 1; mode=block\n    "
--- PASS: TestGetClusterInternalNetworks (1.01s)
=== RUN   TestGetClusterNodes
time="2023-07-13T13:48:25+08:00" level=debug msg="\n    -------------------------- GOISILON HTTP REQUEST -------------------------\n    GET /platform/3/cluster/nodes/ HTTP/1.1\n    Host: 10.225.108.6:8080\n    Authorization: root:******\n    \n"
time="2023-07-13T13:48:26+08:00" level=debug msg="\n    -------------------------- GOISILON HTTP RESPONSE -------------------------\n    HTTP/1.1 200 Ok\n    Transfer-Encoding: chunked\n    Allow: GET, HEAD\n    Content-Security-Policy: default-src 'self' 'unsafe-inline' 'unsafe-eval' data:; script-src 'self' 'unsafe-eval'; style-src 'unsafe-inline' 'self';\n    Content-Type: application/json\n    Date: Thu, 13 Jul 2023 04:28:12 GMT\n    Server: Apache\n    Strict-Transport-Security: max-age=31536000;\n    X-Content-Type-Options: nosniff\n    X-Frame-Options: sameorigin\n    X-Xss-Protection: 1; mode=block\n    "
--- PASS: TestGetClusterNodes (5.02s)
=== RUN   TestGetClusterNode
time="2023-07-13T13:48:30+08:00" level=debug msg="\n    -------------------------- GOISILON HTTP REQUEST -------------------------\n    GET /platform/3/cluster/nodes/1/ HTTP/1.1\n    Host: 10.225.108.6:8080\n    Authorization: root:******\n    \n"
time="2023-07-13T13:48:31+08:00" level=debug msg="\n    -------------------------- GOISILON HTTP RESPONSE -------------------------\n    HTTP/1.1 200 Ok\n    Transfer-Encoding: chunked\n    Allow: GET, PUT, HEAD\n    Content-Security-Policy: default-src 'self' 'unsafe-inline' 'unsafe-eval' data:; script-src 'self' 'unsafe-eval'; style-src 'unsafe-inline' 'self';\n    Content-Type: application/json\n    Date: Thu, 13 Jul 2023 04:28:17 GMT\n    Server: Apache\n    Strict-Transport-Security: max-age=31536000;\n    X-Content-Type-Options: nosniff\n    X-Frame-Options: sameorigin\n    X-Xss-Protection: 1; mode=block\n    "
--- PASS: TestGetClusterNode (1.88s)
PASS


Process finished with the exit code 0

```

## Description of your changes:
- Add onefs version and timezone variables to cluster config API
- Add cluster identity API
- Add cluster ACS API
- Add cluster internal networks API
- Add API for query single and multiple cluster nodes
