### PR TITLE
Implement API for user group

### DIFF
--- a/api/v1/api_v1.go
+++ b/api/v1/api_v1.go
@@ -35,6 +35,8 @@ const (
 	userPath            = "platform/1/auth/users"
 	rolePath            = "platform/1/auth/roles"
 	roleMemberPath      = "platform/1/auth/roles/%s/members"
+	groupPath           = "platform/1/auth/groups"
+	groupMemberPath     = "platform/1/auth/groups/%s/members"
 )
 
 var (

--- a/api/v1/api_v1_types.go
+++ b/api/v1/api_v1_types.go
@@ -397,3 +397,62 @@ type IsiRoleListRespResume struct {
 	Roles  []*IsiRole `json:"roles,omitempty"`
 	Total  *int32     `json:"total,omitempty"`
 }
+
+// IsiGroup Specifies configuration properties for a group.
+type IsiGroup struct {
+	// Specifies the distinguished name for the user.
+	Dn string `json:"dn"`
+	// Specifies the DNS domain.
+	DnsDomain string `json:"dns_domain"`
+	// Specifies the domain that the object is part of.
+	Domain string `json:"domain"`
+	// If true, the GID was generated.
+	GeneratedGid bool                   `json:"generated_gid"`
+	Gid          IsiAccessItemFileGroup `json:"gid"`
+	// Specifies the user or group ID.
+	Id string `json:"id"`
+	// Specifies the groups that this user or group are members of.
+	MemberOf []IsiAccessItemFileGroup `json:"member_of"`
+	// Specifies a user or group name.
+	Name string `json:"name"`
+	// ObjectHistory []V1AuthGroupObjectHistoryItem `json:"object_history,omitempty"`
+	// Specifies the authentication provider that the object belongs to.
+	Provider string `json:"provider"`
+	// Specifies a user or group name.
+	SamAccountName string                 `json:"sam_account_name"`
+	Sid            IsiAccessItemFileGroup `json:"sid"`
+	// Specifies the object type.
+	Type string `json:"type"`
+}
+
+// IsiGroupReq Specifies the configuration properties for a group.
+type IsiGroupReq struct {
+	// Specifies the numeric group identifier.
+	Gid *int32 `json:"gid,omitempty"`
+	// Specifies the members of the group.
+	Members []IsiAccessItemFileGroup `json:"members,omitempty"`
+	// Specifies the group name.
+	Name string `json:"name"`
+}
+
+// IsiUpdateGroupReq Specifies the configuration properties for a group.
+type IsiUpdateGroupReq struct {
+	// Specifies the numeric group identifier.
+	Gid int32 `json:"gid,omitempty"`
+}
+
+type IsiGroupMemberListRespResume struct {
+	Members []*IsiAccessItemFileGroup `json:"members,omitempty"`
+	Resume  string                    `json:"resume,omitempty"`
+}
+
+type isiGroupListResp struct {
+	Groups []*IsiGroup `json:"groups,omitempty"`
+}
+
+type IsiGroupListRespResume struct {
+	// Provide this token as the 'resume' query argument to continue listing results.
+	Groups []*IsiGroup `json:"groups,omitempty"`
+	// Provide this token as the 'resume' query argument to continue listing results.
+	Resume string `json:"resume,omitempty"`
+}

--- a/api/v1/api_v1_user_groups.go
+++ b/api/v1/api_v1_user_groups.go
@@ -1,0 +1,299 @@
+/*
+Copyright (c) 2023 Dell Inc, or its subsidiaries.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package v1
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/dell/goisilon/api"
+)
+
+// GetIsiGroup queries the group by group-id.
+func GetIsiGroup(ctx context.Context, client api.Client, groupName *string, gid *int32) (group *IsiGroup, err error) {
+
+	// PAPI call: GET https://1.2.3.4:8080/platform/1/auth/groups/<group-id>
+
+	authGroupId, err := getAuthMemberId(fileGroupTypeGroup, groupName, gid)
+	if err != nil {
+		return
+	}
+
+	var groupListResp *isiGroupListResp
+	if err = client.Get(ctx, groupPath, authGroupId, nil, nil, &groupListResp); err != nil {
+		return
+	}
+
+	if groupListResp.Groups != nil && len(groupListResp.Groups) > 0 {
+		group = groupListResp.Groups[0]
+		return
+	}
+
+	return nil, fmt.Errorf("group not found: %s", authGroupId)
+}
+
+// GetIsiGroupList queries all groups on the cluster with filter,
+// filter by namePrefix, domain, zone, provider, cached, resolveNames, memberOf, zone and limit.
+func GetIsiGroupList(ctx context.Context, client api.Client,
+	queryNamePrefix, queryDomain, queryZone, queryProvider *string,
+	queryCached, queryResolveNames, queryMemberOf *bool,
+	queryLimit *int32) (groups []*IsiGroup, err error) {
+
+	// PAPI call: GET https://1.2.3.4:8080/platform/1/auth/groups?limit=&domain=&cached=&resolve_names=&query_member_of=&zone=&provider=&filter=
+	values := api.OrderedValues{}
+	if queryCached != nil {
+		values.StringAdd("cached", fmt.Sprintf("%t", *queryCached))
+	}
+	if queryDomain != nil {
+		values.StringAdd("domain", *queryDomain)
+	}
+	if queryNamePrefix != nil {
+		values.StringAdd("filter", *queryNamePrefix)
+	}
+	if queryResolveNames != nil {
+		values.StringAdd("resolve_names", fmt.Sprintf("%t", *queryResolveNames))
+	}
+	if queryMemberOf != nil {
+		values.StringAdd("query_member_of", fmt.Sprintf("%t", *queryMemberOf))
+	}
+	if queryZone != nil {
+		values.StringAdd("zone", *queryZone)
+	}
+	if queryProvider != nil {
+		values.StringAdd("provider", *queryProvider)
+	}
+	if queryLimit != nil {
+		values.StringAdd("limit", fmt.Sprintf("%d", *queryLimit))
+	}
+
+	var groupListResp *IsiGroupListRespResume
+	// First call without Resume param
+	if err = client.Get(ctx, groupPath, "", values, nil, &groupListResp); err != nil {
+		return
+	}
+
+	for {
+		groups = append(groups, groupListResp.Groups...)
+		if groupListResp.Resume == "" {
+			break
+		}
+
+		if groupListResp, err = getIsiGroupListWithResume(ctx, client, groupListResp.Resume); err != nil {
+			return nil, err
+		}
+	}
+	return
+}
+
+// getIsiGroupListWithResume queries the next page groups based on resume token.
+func getIsiGroupListWithResume(ctx context.Context, client api.Client, resume string) (groups *IsiGroupListRespResume, err error) {
+
+	err = client.Get(ctx, groupPath, "", api.OrderedValues{{[]byte("resume"), []byte(resume)}}, nil, &groups)
+	return
+}
+
+// GetIsiGroupMembers retrieves the members of a group.
+func GetIsiGroupMembers(ctx context.Context, client api.Client, groupName *string, gid *int32) (members []*IsiAccessItemFileGroup, err error) {
+
+	// PAPI call: GET https://1.2.3.4:8080/platform/1/groups/{group-id}/members
+
+	authGroupId, err := getAuthMemberId(fileGroupTypeGroup, groupName, gid)
+	if err != nil {
+		return
+	}
+
+	var groupMemberListResp *IsiGroupMemberListRespResume
+	// First call without Resume param
+	if err = client.Get(ctx, fmt.Sprintf(groupMemberPath, authGroupId), "", nil, nil, &groupMemberListResp); err != nil {
+		return
+	}
+
+	for {
+		members = append(members, groupMemberListResp.Members...)
+		if groupMemberListResp.Resume == "" {
+			break
+		}
+
+		if groupMemberListResp, err = getIsiGroupMemberListWithResume(ctx, client, authGroupId, groupMemberListResp.Resume); err != nil {
+			return nil, err
+		}
+	}
+	return
+}
+
+// getIsiGroupMemberListWithResume queries the next page group members based on resume token.
+func getIsiGroupMemberListWithResume(ctx context.Context, client api.Client, groupId, resume string) (members *IsiGroupMemberListRespResume, err error) {
+
+	err = client.Get(ctx, fmt.Sprintf(groupMemberPath, groupId), "", api.OrderedValues{{[]byte("resume"), []byte(resume)}}, nil, &members)
+	return
+}
+
+// AddIsiGroupMember adds a member to the group, member can be a user/group.
+func AddIsiGroupMember(ctx context.Context, client api.Client, groupName *string, gid *int32, member IsiAuthMemberItem) error {
+
+	// PAPI call: POST https://1.2.3.4:8080/platform/1/groups/{group-id}/members
+	//					{
+	//					 	"type":"user",
+	//					 	"name":"user123",
+	//						"id":"UID:1522"
+	//					}
+
+	authGroupId, err := getAuthMemberId(fileGroupTypeGroup, groupName, gid)
+	if err != nil {
+		return err
+	}
+
+	memberType := strings.ToLower(member.Type)
+	if memberType != fileGroupTypeUser && memberType != fileGroupTypeGroup {
+		return fmt.Errorf("member type is wrong, only support %s and %s", fileGroupTypeUser, fileGroupTypeGroup)
+	}
+
+	data := &IsiAccessItemFileGroup{}
+	if member.Id != nil {
+		data.Id = fmt.Sprintf("%sID:%d", strings.ToUpper(memberType)[0:1], *member.Id)
+	}
+	if member.Name != nil && *member.Name != "" {
+		data.Name = *member.Name
+	}
+
+	return client.Post(ctx, fmt.Sprintf(groupMemberPath, authGroupId), "", nil, nil, data, nil)
+}
+
+// RemoveIsiGroupMember remove a member from the group, member can be user/group.
+func RemoveIsiGroupMember(ctx context.Context, client api.Client, groupName *string, gid *int32, member IsiAuthMemberItem) error {
+
+	// PAPI call: DELETE https://1.2.3.4:8080/platform/1/groups/{group-id}/members/<member-id>
+
+	authGroupId, err := getAuthMemberId(fileGroupTypeGroup, groupName, gid)
+	if err != nil {
+		return err
+	}
+
+	authMemberId, err := getAuthMemberId(member.Type, member.Name, member.Id)
+	if err != nil {
+		return err
+	}
+
+	return client.Delete(ctx, fmt.Sprintf(groupMemberPath, authGroupId), authMemberId, nil, nil, nil)
+}
+
+// CreateIsiGroup creates a new group.
+func CreateIsiGroup(ctx context.Context, client api.Client,
+	name string, gid *int32, members []IsiAuthMemberItem,
+	queryForce *bool, queryZone, queryProvider *string) (string, error) {
+
+	// PAPI call: POST https://1.2.3.4:8080/platform/1/auth/groups?force=&zone=&provider=
+	// 				{
+	// 					"gid": "int",
+	// 					"name": "str",
+	// 					"members":
+	// 					[
+	//					{
+	// 						"type":"str",
+	// 						"id":"str",
+	// 						"name":"str"
+	// 					},
+	// 					],
+	//				}
+
+	values := api.OrderedValues{}
+	if queryForce != nil {
+		values.StringAdd("force", fmt.Sprintf("%t", *queryForce))
+	}
+	if queryZone != nil {
+		values.StringAdd("zone", *queryZone)
+	}
+	if queryProvider != nil {
+		values.StringAdd("provider", *queryProvider)
+	}
+
+	var memberList []IsiAccessItemFileGroup
+	for _, m := range members {
+
+		memberType := strings.ToLower(m.Type)
+		if memberType != fileGroupTypeUser && memberType != fileGroupTypeGroup {
+			return "", fmt.Errorf("member type is wrong, only support %s and %s", fileGroupTypeUser, fileGroupTypeGroup)
+		}
+
+		member := &IsiAccessItemFileGroup{
+			Type: memberType,
+		}
+
+		if m.Id != nil {
+			member.Id = fmt.Sprintf("%sID:%d", strings.ToUpper(memberType)[0:1], *m.Id)
+		} else if m.Name != nil && *m.Name != "" {
+			member.Name = *m.Name
+		} else {
+			continue
+		}
+
+		memberList = append(memberList, *member)
+	}
+
+	data := &IsiGroupReq{
+		Name:    name,
+		Gid:     gid,
+		Members: memberList,
+	}
+
+	var groupResp *IsiGroup
+	if err := client.Post(ctx, groupPath, "", values, nil, data, &groupResp); err != nil {
+		return "", err
+	}
+
+	return groupResp.Id, nil
+}
+
+// UpdateIsiGroupGID updates the group's gid.
+func UpdateIsiGroupGID(ctx context.Context, client api.Client, groupName *string, gid *int32, newGid int32,
+	queryZone, queryProvider *string) (err error) {
+
+	// PAPI call: PUT https://1.2.3.4:8080/platform/1/auth/groups/<group-id>?force=true&zone=&provider=
+	// 				{
+	// 					"gid": int
+	//				}
+
+	// set force to true to change group's gid
+	values := api.OrderedValues{{[]byte("force"), []byte("true")}}
+
+	if queryZone != nil {
+		values.StringAdd("zone", *queryZone)
+	}
+
+	if queryProvider != nil {
+		values.StringAdd("provider", *queryProvider)
+	}
+
+	authGroupId, err := getAuthMemberId(fileGroupTypeGroup, groupName, gid)
+	if err != nil {
+		return
+	}
+
+	return client.Put(ctx, groupPath, authGroupId, values, nil, &IsiUpdateGroupReq{newGid}, nil)
+}
+
+// DeleteIsiGroup removes the group by group-id.
+func DeleteIsiGroup(ctx context.Context, client api.Client, groupName *string, gid *int32) (err error) {
+
+	// PAPI call: DELETE https://1.2.3.4:8080/platform/1/auth/groups/<group-id>
+	authGroupId, err := getAuthMemberId(fileGroupTypeGroup, groupName, gid)
+	if err != nil {
+		return
+	}
+
+	return client.Delete(ctx, groupPath, authGroupId, nil, nil, nil)
+}

--- a/role_test.go
+++ b/role_test.go
@@ -24,7 +24,7 @@ import (
 
 // Test GetAllRoles() and GetRolesWithFilter()
 func TestRoleGet(t *testing.T) {
-	// Get roles witl filter
+	// Get roles with filter
 	queryResolveNames := true
 	var queryLimit int32 = 1000
 

--- a/user_group.go
+++ b/user_group.go
@@ -1,0 +1,97 @@
+/*
+Copyright (c) 2023 Dell Inc, or its subsidiaries.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package goisilon
+
+import (
+	"context"
+
+	api "github.com/dell/goisilon/api/v1"
+)
+
+// Group maps to an Isilon Group.
+type Group *api.IsiGroup
+
+// GroupList maps to a set of groups.
+type GroupList []*api.IsiGroup
+
+// GroupMemberList maps to a set of group members.
+type GroupMemberList []*api.IsiAccessItemFileGroup
+
+// GetGroupByNameOrGID returns a specific group by group name or gid.
+func (c *Client) GetGroupByNameOrGID(ctx context.Context, name *string, gid *int32) (Group, error) {
+	return api.GetIsiGroup(ctx, c.API, name, gid)
+}
+
+// GetAllGroups returns all groups on the cluster.
+func (c *Client) GetAllGroups(ctx context.Context) (GroupList, error) {
+	return c.GetGroupsWithFilter(ctx, nil, nil, nil, nil, nil, nil, nil, nil)
+}
+
+// GetGroupsWithFilter returns groups on the cluster with
+// Optional filter: namePrefix, domain, zone, provider, cached, resolveNames, memberOf, zone and limit.
+func (c *Client) GetGroupsWithFilter(ctx context.Context,
+	queryNamePrefix, queryDomain, queryZone, queryProvider *string,
+	queryCached, queryResolveNames, queryMemberOf *bool,
+	queryLimit *int32) (GroupList, error) {
+
+	return api.GetIsiGroupList(ctx, c.API, queryNamePrefix, queryDomain, queryZone, queryProvider, queryCached, queryResolveNames, queryMemberOf, queryLimit)
+}
+
+// GetGroupMembers retrieves the members of a group by name or gid.
+func (c *Client) GetGroupMembers(ctx context.Context, name *string, gid *int32) (GroupMemberList, error) {
+	return api.GetIsiGroupMembers(ctx, c.API, name, gid)
+}
+
+// AddGroupMember adds a member to a specific group,
+// Required: groupName/gid, member,
+// member can be a user or group.
+func (c *Client) AddGroupMember(ctx context.Context, name *string, gid *int32, member api.IsiAuthMemberItem) error {
+	return api.AddIsiGroupMember(ctx, c.API, name, gid, member)
+}
+
+// RemoveGroupMember removes a member from a specific group,
+// Required: groupName/gid, member,
+// member can be a user or group.
+func (c *Client) RemoveGroupMember(ctx context.Context, name *string, gid *int32, member api.IsiAuthMemberItem) error {
+	return api.RemoveIsiGroupMember(ctx, c.API, name, gid, member)
+}
+
+// CreatGroupByName creates a new group with name.
+func (c *Client) CreatGroupByName(ctx context.Context, name string) (string, error) {
+	return c.CreateGroupWithOptions(ctx, name, nil, nil, nil, nil, nil)
+}
+
+// CreateGroupWithOptions creates a new group with name(required), gid(optional), and members(optional),
+// Optional filter: force, zone and provider.
+func (c *Client) CreateGroupWithOptions(
+	ctx context.Context, name string, gid *int32, members []api.IsiAuthMemberItem,
+	queryForce *bool, queryZone, queryProvider *string) (string, error) {
+	return api.CreateIsiGroup(ctx, c.API, name, gid, members, queryForce, queryZone, queryProvider)
+}
+
+// UpdateIsiGroupGIDByNameOrUID modifies a specific group's gid by group name or gid with
+// Required: newGid,
+// Optional filter: zone and provider.
+func (c *Client) UpdateIsiGroupGIDByNameOrUID(
+	ctx context.Context, name *string, gid *int32, newGid int32, queryZone, queryProvider *string) error {
+	return api.UpdateIsiGroupGID(ctx, c.API, name, gid, newGid, queryZone, queryProvider)
+}
+
+// DeleteGroupByNameOrGID deletes a specific group by group name or gid.
+func (c *Client) DeleteGroupByNameOrGID(ctx context.Context, name *string, gid *int32) error {
+	return api.DeleteIsiGroup(ctx, c.API, name, gid)
+}

--- a/user_group_test.go
+++ b/user_group_test.go
@@ -1,0 +1,151 @@
+/*
+Copyright (c) 2023 Dell Inc, or its subsidiaries.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package goisilon
+
+import (
+	"fmt"
+	"strconv"
+	"testing"
+
+	api "github.com/dell/goisilon/api/v1"
+	"github.com/stretchr/testify/assert"
+)
+
+// Test GetAllGroups() and GetGroupsWithFilter()
+func TestGroupGet(t *testing.T) {
+	// Get groups with filter
+	queryCached := false
+	queryResolveNames := false
+	queryMemberOf := false
+	var queryLimit int32 = 1000
+
+	groups, err := client.GetGroupsWithFilter(defaultCtx, nil, nil, nil, nil, &queryCached, &queryResolveNames, &queryMemberOf, &queryLimit)
+	if err != nil {
+		panic(err)
+	}
+
+	// Get All groups
+	allGroups, err := client.GetAllGroups(defaultCtx)
+	if err != nil {
+		panic(err)
+	}
+
+	assert.True(t, len(allGroups) >= len(groups))
+}
+
+// Test GetGroupByNameOrGID(), CreateGroupWithOptions() and DeleteGroupByNameOrGID()
+func TestGroupCreate(t *testing.T) {
+	userName := "test_user_group_member"
+	groupName := "test_group_create_options"
+	gid := int32(100000)
+	queryForce := true
+
+	_, err = client.CreateUserByName(defaultCtx, userName)
+	if err != nil {
+		panic(err)
+	}
+	defer client.DeleteUserByNameOrUID(defaultCtx, &userName, nil)
+	user, err := client.GetUserByNameOrUID(defaultCtx, &userName, nil)
+	if err != nil {
+		panic(err)
+	}
+	uid, err := strconv.ParseInt(user.Uid.Id[4:], 10, 32)
+	uid32 := int32(uid)
+	if err != nil {
+		panic(err)
+	}
+	member := []api.IsiAuthMemberItem{{Name: &userName, Id: &uid32, Type: "user"}}
+
+	_, err = client.CreateGroupWithOptions(defaultCtx, groupName, &gid, member, &queryForce, nil, nil)
+	assertNoError(t, err)
+
+	group, err := client.GetGroupByNameOrGID(defaultCtx, nil, &gid)
+	assertNoError(t, err)
+	assertNotNil(t, group)
+	assertEqual(t, fmt.Sprintf("GID:%d", gid), group.Gid.Id)
+
+	err = client.DeleteGroupByNameOrGID(defaultCtx, nil, &gid)
+	assertNoError(t, err)
+
+	group, err = client.GetGroupByNameOrGID(defaultCtx, &groupName, &gid)
+	assertError(t, err)
+	assertNil(t, group)
+}
+
+// Test GetGroupByNameOrGID(), CreatGroupByName(), UpdateIsiGroupGIDByNameOrUID() and DeleteGroupByNameOrGID()
+func TestGroupUpdate(t *testing.T) {
+
+	groupName := "test_group_create_update"
+	_, err := client.CreatGroupByName(defaultCtx, groupName)
+	defer client.DeleteGroupByNameOrGID(defaultCtx, &groupName, nil)
+	assertNoError(t, err)
+
+	group, err := client.GetGroupByNameOrGID(defaultCtx, &groupName, nil)
+	assertNoError(t, err)
+	assertNotNil(t, group)
+
+	newGid := int32(10000)
+	err = client.UpdateIsiGroupGIDByNameOrUID(defaultCtx, &groupName, nil, newGid, nil, nil)
+	assertNoError(t, err)
+
+	groupNew, err := client.GetGroupByNameOrGID(defaultCtx, &groupName, &newGid)
+	assertNoError(t, err)
+	assertNotNil(t, groupNew)
+	assertEqual(t, group.Dn, groupNew.Dn)
+	assertEqual(t, group.Provider, groupNew.Provider)
+	assertEqual(t, fmt.Sprintf("GID:%d", newGid), groupNew.Gid.Id)
+	assertNotEqual(t, group.Gid.Id, groupNew.Gid.Id)
+}
+
+// Test GetGroupMembers(), AddGroupMember() and RemoveGroupMember()
+func TestGroupMemberAdd(t *testing.T) {
+	groupName := "test_group_add_member"
+	_, err := client.CreatGroupByName(defaultCtx, groupName)
+	defer client.DeleteGroupByNameOrGID(defaultCtx, &groupName, nil)
+	assertNoError(t, err)
+
+	group, err := client.GetGroupByNameOrGID(defaultCtx, &groupName, nil)
+	assertNoError(t, err)
+	assertNotNil(t, group)
+
+	members, err := client.GetGroupMembers(defaultCtx, &groupName, nil)
+	assertNoError(t, err)
+	assertEqual(t, 0, len(members))
+
+	userName := "test_user_group_add_member"
+	_, err = client.CreateUserByName(defaultCtx, userName)
+	if err != nil {
+		panic(err)
+	}
+	defer client.DeleteUserByNameOrUID(defaultCtx, &userName, nil)
+
+	userMember := api.IsiAuthMemberItem{Name: &userName, Type: "user"}
+	err = client.AddGroupMember(defaultCtx, &groupName, nil, userMember)
+	assertNoError(t, err)
+
+	members, err = client.GetGroupMembers(defaultCtx, &groupName, nil)
+	assertNoError(t, err)
+	assertEqual(t, 1, len(members))
+	assertEqual(t, userName, members[0].Name)
+
+	// remove group member
+	err = client.RemoveGroupMember(defaultCtx, &groupName, nil, userMember)
+	assertNoError(t, err)
+
+	members, err = client.GetGroupMembers(defaultCtx, &groupName, nil)
+	assertNoError(t, err)
+	assertEqual(t, 0, len(members))
+}

--- a/user_test.go
+++ b/user_test.go
@@ -24,7 +24,7 @@ import (
 
 // Test GetAllUsers() and GetUsersWithFilter()
 func TestUserGet(t *testing.T) {
-	// Get users witl filter
+	// Get users with filter
 	queryNamePrefix := "admin"
 	queryCached := false
 	queryResolveNames := false


### PR DESCRIPTION
Implement API for user group
 - add CRUD API for user group
 - add add/remove groupMemebr API for user group

# PR Submission checklist

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
| https://github.com/dell/csm/issues/888 |

# Common PR Checklist:

- [x] Have you made sure that the code compiles?
- [x] Have you commented your code, particularly in hard-to-understand areas
- [ ] Did you run tests in a real Kubernetes cluster?
- [x] Have you maintained backward compatibility

All unit tests for user group are passed:
```

time="2023-07-13T11:10:48+08:00" level=debug msg="opts.Insecure : 'true'"
time="2023-07-13T11:10:48+08:00" level=debug msg="\n    -------------------------- GOISILON HTTP REQUEST -------------------------\n    GET /platform/latest/ HTTP/1.1\n    Host: 10.230.24.249:8080\n    Authorization: root:******\n    \n"
time="2023-07-13T11:10:49+08:00" level=debug msg="\n    -------------------------- GOISILON HTTP RESPONSE -------------------------\n    HTTP/1.1 200 Ok\n    Transfer-Encoding: chunked\n    Content-Security-Policy: default-src 'self' 'unsafe-inline' 'unsafe-eval' data:; script-src 'self' 'unsafe-eval'; style-src 'unsafe-inline' 'self';\n    Content-Type: application/json\n    Date: Thu, 13 Jul 2023 03:10:48 GMT\n    Server: Apache\n    Strict-Transport-Security: max-age=31536000;\n    X-Content-Type-Options: nosniff\n    X-Frame-Options: sameorigin\n    X-Xss-Protection: 1; mode=block\n    "
=== RUN   TestGroupGet
time="2023-07-13T11:10:49+08:00" level=debug msg="\n    -------------------------- GOISILON HTTP REQUEST -------------------------\n    GET /platform/1/auth/groups/?cached=false&resolve_names=false&query_member_of=false&limit=1000 HTTP/1.1\n    Host: 10.230.24.249:8080\n    Authorization: root:******\n    \n"
time="2023-07-13T11:10:50+08:00" level=debug msg="\n    -------------------------- GOISILON HTTP RESPONSE -------------------------\n    HTTP/1.1 200 Ok\n    Transfer-Encoding: chunked\n    Allow: GET, POST, DELETE, HEAD\n    Content-Security-Policy: default-src 'self' 'unsafe-inline' 'unsafe-eval' data:; script-src 'self' 'unsafe-eval'; style-src 'unsafe-inline' 'self';\n    Content-Type: application/json\n    Date: Thu, 13 Jul 2023 03:10:49 GMT\n    Server: Apache\n    Strict-Transport-Security: max-age=31536000;\n    X-Content-Type-Options: nosniff\n    X-Frame-Options: sameorigin\n    X-Xss-Protection: 1; mode=block\n    "
time="2023-07-13T11:10:50+08:00" level=debug msg="\n    -------------------------- GOISILON HTTP REQUEST -------------------------\n    GET /platform/1/auth/groups/ HTTP/1.1\n    Host: 10.230.24.249:8080\n    Authorization: root:******\n    \n"
time="2023-07-13T11:10:52+08:00" level=debug msg="\n    -------------------------- GOISILON HTTP RESPONSE -------------------------\n    HTTP/1.1 200 Ok\n    Transfer-Encoding: chunked\n    Allow: GET, POST, DELETE, HEAD\n    Content-Security-Policy: default-src 'self' 'unsafe-inline' 'unsafe-eval' data:; script-src 'self' 'unsafe-eval'; style-src 'unsafe-inline' 'self';\n    Content-Type: application/json\n    Date: Thu, 13 Jul 2023 03:10:50 GMT\n    Server: Apache\n    Strict-Transport-Security: max-age=31536000;\n    X-Content-Type-Options: nosniff\n    X-Frame-Options: sameorigin\n    X-Xss-Protection: 1; mode=block\n    "
--- PASS: TestGroupGet (2.47s)
=== RUN   TestGroupCreate
time="2023-07-13T11:10:52+08:00" level=debug msg="\n    -------------------------- GOISILON HTTP REQUEST -------------------------\n    POST /platform/1/auth/users/ HTTP/1.1\n    Host: 10.230.24.249:8080\n    Authorization: root:******\n    Content-Type: application/json\n    \n    {\"name\":\"test_user_group_member\"}\n"
time="2023-07-13T11:10:53+08:00" level=debug msg="\n    -------------------------- GOISILON HTTP RESPONSE -------------------------\n    HTTP/1.1 201 Created\n    Transfer-Encoding: chunked\n    Allow: GET, POST, DELETE, HEAD\n    Content-Security-Policy: default-src 'self' 'unsafe-inline' 'unsafe-eval' data:; script-src 'self' 'unsafe-eval'; style-src 'unsafe-inline' 'self';\n    Content-Type: application/json\n    Date: Thu, 13 Jul 2023 03:10:52 GMT\n    Location: /1/auth/users/SID%!A(MISSING)S-1-5-21-2193650305-1279797252-961391754-1156\n    Server: Apache\n    Strict-Transport-Security: max-age=31536000;\n    X-Content-Type-Options: nosniff\n    X-Frame-Options: sameorigin\n    X-Xss-Protection: 1; mode=block\n    "
time="2023-07-13T11:10:53+08:00" level=debug msg="\n    -------------------------- GOISILON HTTP REQUEST -------------------------\n    GET /platform/1/auth/users/USER:test_user_group_member HTTP/1.1\n    Host: 10.230.24.249:8080\n    Authorization: root:******\n    \n"
time="2023-07-13T11:10:54+08:00" level=debug msg="\n    -------------------------- GOISILON HTTP RESPONSE -------------------------\n    HTTP/1.1 200 Ok\n    Transfer-Encoding: chunked\n    Allow: GET, PUT, DELETE, HEAD\n    Content-Security-Policy: default-src 'self' 'unsafe-inline' 'unsafe-eval' data:; script-src 'self' 'unsafe-eval'; style-src 'unsafe-inline' 'self';\n    Content-Type: application/json\n    Date: Thu, 13 Jul 2023 03:10:53 GMT\n    Server: Apache\n    Strict-Transport-Security: max-age=31536000;\n    X-Content-Type-Options: nosniff\n    X-Frame-Options: sameorigin\n    X-Xss-Protection: 1; mode=block\n    "
time="2023-07-13T11:10:54+08:00" level=debug msg="\n    -------------------------- GOISILON HTTP REQUEST -------------------------\n    POST /platform/1/auth/groups/?force=true HTTP/1.1\n    Host: 10.230.24.249:8080\n    Authorization: root:******\n    Content-Type: application/json\n    \n    {\"gid\":100000,\"members\":[{\"id\":\"UID:2120\",\"type\":\"user\"}],\"name\":\"test_group_create_options\"}\n"
time="2023-07-13T11:10:55+08:00" level=debug msg="\n    -------------------------- GOISILON HTTP RESPONSE -------------------------\n    HTTP/1.1 201 Created\n    Transfer-Encoding: chunked\n    Allow: GET, POST, DELETE, HEAD\n    Content-Security-Policy: default-src 'self' 'unsafe-inline' 'unsafe-eval' data:; script-src 'self' 'unsafe-eval'; style-src 'unsafe-inline' 'self';\n    Content-Type: application/json\n    Date: Thu, 13 Jul 2023 03:10:54 GMT\n    Location: /1/auth/groups/SID%!A(MISSING)S-1-5-21-2193650305-1279797252-961391754-1157\n    Server: Apache\n    Strict-Transport-Security: max-age=31536000;\n    X-Content-Type-Options: nosniff\n    X-Frame-Options: sameorigin\n    X-Xss-Protection: 1; mode=block\n    "
time="2023-07-13T11:10:55+08:00" level=debug msg="\n    -------------------------- GOISILON HTTP REQUEST -------------------------\n    GET /platform/1/auth/groups/GID:100000 HTTP/1.1\n    Host: 10.230.24.249:8080\n    Authorization: root:******\n    \n"
time="2023-07-13T11:10:56+08:00" level=debug msg="\n    -------------------------- GOISILON HTTP RESPONSE -------------------------\n    HTTP/1.1 200 Ok\n    Transfer-Encoding: chunked\n    Allow: GET, PUT, DELETE, HEAD\n    Content-Security-Policy: default-src 'self' 'unsafe-inline' 'unsafe-eval' data:; script-src 'self' 'unsafe-eval'; style-src 'unsafe-inline' 'self';\n    Content-Type: application/json\n    Date: Thu, 13 Jul 2023 03:10:55 GMT\n    Server: Apache\n    Strict-Transport-Security: max-age=31536000;\n    X-Content-Type-Options: nosniff\n    X-Frame-Options: sameorigin\n    X-Xss-Protection: 1; mode=block\n    "
time="2023-07-13T11:10:56+08:00" level=debug msg="\n    -------------------------- GOISILON HTTP REQUEST -------------------------\n    DELETE /platform/1/auth/groups/GID:100000 HTTP/1.1\n    Host: 10.230.24.249:8080\n    Authorization: root:******\n    \n"
time="2023-07-13T11:10:58+08:00" level=debug msg="\n    -------------------------- GOISILON HTTP RESPONSE -------------------------\n    HTTP/1.1 204 No Content\n    Allow: GET, PUT, DELETE, HEAD\n    Content-Security-Policy: default-src 'self' 'unsafe-inline' 'unsafe-eval' data:; script-src 'self' 'unsafe-eval'; style-src 'unsafe-inline' 'self';\n    Date: Thu, 13 Jul 2023 03:10:57 GMT\n    Server: Apache\n    Strict-Transport-Security: max-age=31536000;\n    X-Content-Type-Options: nosniff\n    X-Frame-Options: sameorigin\n    X-Xss-Protection: 1; mode=block\n    "
time="2023-07-13T11:10:58+08:00" level=debug msg="\n    -------------------------- GOISILON HTTP REQUEST -------------------------\n    GET /platform/1/auth/groups/GID:100000 HTTP/1.1\n    Host: 10.230.24.249:8080\n    Authorization: root:******\n    \n"
time="2023-07-13T11:10:58+08:00" level=debug msg="\n    -------------------------- GOISILON HTTP RESPONSE -------------------------\n    HTTP/1.1 404 Not Found\n    Transfer-Encoding: chunked\n    Allow: GET, PUT, DELETE, HEAD\n    Content-Security-Policy: default-src 'self' 'unsafe-inline' 'unsafe-eval' data:; script-src 'self' 'unsafe-eval'; style-src 'unsafe-inline' 'self';\n    Content-Type: application/json\n    Date: Thu, 13 Jul 2023 03:10:57 GMT\n    Server: Apache\n    Strict-Transport-Security: max-age=31536000;\n    X-Content-Type-Options: nosniff\n    X-Frame-Options: sameorigin\n    X-Xss-Protection: 1; mode=block\n    "
time="2023-07-13T11:10:58+08:00" level=debug msg="\n    -------------------------- GOISILON HTTP REQUEST -------------------------\n    DELETE /platform/1/auth/users/USER:test_user_group_member HTTP/1.1\n    Host: 10.230.24.249:8080\n    Authorization: root:******\n    \n"
time="2023-07-13T11:10:59+08:00" level=debug msg="\n    -------------------------- GOISILON HTTP RESPONSE -------------------------\n    HTTP/1.1 204 No Content\n    Allow: GET, PUT, DELETE, HEAD\n    Content-Security-Policy: default-src 'self' 'unsafe-inline' 'unsafe-eval' data:; script-src 'self' 'unsafe-eval'; style-src 'unsafe-inline' 'self';\n    Date: Thu, 13 Jul 2023 03:10:58 GMT\n    Server: Apache\n    Strict-Transport-Security: max-age=31536000;\n    X-Content-Type-Options: nosniff\n    X-Frame-Options: sameorigin\n    X-Xss-Protection: 1; mode=block\n    "
--- PASS: TestGroupCreate (7.88s)
=== RUN   TestGroupUpdate
time="2023-07-13T11:10:59+08:00" level=debug msg="\n    -------------------------- GOISILON HTTP REQUEST -------------------------\n    POST /platform/1/auth/groups/ HTTP/1.1\n    Host: 10.230.24.249:8080\n    Authorization: root:******\n    Content-Type: application/json\n    \n    {\"name\":\"test_group_create_update\"}\n"
time="2023-07-13T11:11:00+08:00" level=debug msg="\n    -------------------------- GOISILON HTTP RESPONSE -------------------------\n    HTTP/1.1 201 Created\n    Transfer-Encoding: chunked\n    Allow: GET, POST, DELETE, HEAD\n    Content-Security-Policy: default-src 'self' 'unsafe-inline' 'unsafe-eval' data:; script-src 'self' 'unsafe-eval'; style-src 'unsafe-inline' 'self';\n    Content-Type: application/json\n    Date: Thu, 13 Jul 2023 03:10:59 GMT\n    Location: /1/auth/groups/SID%!A(MISSING)S-1-5-21-2193650305-1279797252-961391754-1158\n    Server: Apache\n    Strict-Transport-Security: max-age=31536000;\n    X-Content-Type-Options: nosniff\n    X-Frame-Options: sameorigin\n    X-Xss-Protection: 1; mode=block\n    "
time="2023-07-13T11:11:00+08:00" level=debug msg="\n    -------------------------- GOISILON HTTP REQUEST -------------------------\n    GET /platform/1/auth/groups/GROUP:test_group_create_update HTTP/1.1\n    Host: 10.230.24.249:8080\n    Authorization: root:******\n    \n"
time="2023-07-13T11:11:01+08:00" level=debug msg="\n    -------------------------- GOISILON HTTP RESPONSE -------------------------\n    HTTP/1.1 200 Ok\n    Transfer-Encoding: chunked\n    Allow: GET, PUT, DELETE, HEAD\n    Content-Security-Policy: default-src 'self' 'unsafe-inline' 'unsafe-eval' data:; script-src 'self' 'unsafe-eval'; style-src 'unsafe-inline' 'self';\n    Content-Type: application/json\n    Date: Thu, 13 Jul 2023 03:11:00 GMT\n    Server: Apache\n    Strict-Transport-Security: max-age=31536000;\n    X-Content-Type-Options: nosniff\n    X-Frame-Options: sameorigin\n    X-Xss-Protection: 1; mode=block\n    "
time="2023-07-13T11:11:01+08:00" level=debug msg="\n    -------------------------- GOISILON HTTP REQUEST -------------------------\n    PUT /platform/1/auth/groups/GROUP:test_group_create_update?force=true HTTP/1.1\n    Host: 10.230.24.249:8080\n    Authorization: root:******\n    Content-Type: application/json\n    \n    {\"gid\":10000}\n"
time="2023-07-13T11:11:02+08:00" level=debug msg="\n    -------------------------- GOISILON HTTP RESPONSE -------------------------\n    HTTP/1.1 204 No Content\n    Content-Length: 0\n    Allow: GET, PUT, DELETE, HEAD\n    Content-Security-Policy: default-src 'self' 'unsafe-inline' 'unsafe-eval' data:; script-src 'self' 'unsafe-eval'; style-src 'unsafe-inline' 'self';\n    Date: Thu, 13 Jul 2023 03:11:01 GMT\n    Server: Apache\n    Strict-Transport-Security: max-age=31536000;\n    X-Content-Type-Options: nosniff\n    X-Frame-Options: sameorigin\n    X-Xss-Protection: 1; mode=block\n    "       
time="2023-07-13T11:11:02+08:00" level=debug msg="\n    -------------------------- GOISILON HTTP REQUEST -------------------------\n    GET /platform/1/auth/groups/GID:10000 HTTP/1.1\n    Host: 10.230.24.249:8080\n    Authorization: root:******\n    \n"
time="2023-07-13T11:11:03+08:00" level=debug msg="\n    -------------------------- GOISILON HTTP RESPONSE -------------------------\n    HTTP/1.1 200 Ok\n    Transfer-Encoding: chunked\n    Allow: GET, PUT, DELETE, HEAD\n    Content-Security-Policy: default-src 'self' 'unsafe-inline' 'unsafe-eval' data:; script-src 'self' 'unsafe-eval'; style-src 'unsafe-inline' 'self';\n    Content-Type: application/json\n    Date: Thu, 13 Jul 2023 03:11:02 GMT\n    Server: Apache\n    Strict-Transport-Security: max-age=31536000;\n    X-Content-Type-Options: nosniff\n    X-Frame-Options: sameorigin\n    X-Xss-Protection: 1; mode=block\n    "
time="2023-07-13T11:11:03+08:00" level=debug msg="\n    -------------------------- GOISILON HTTP REQUEST -------------------------\n    DELETE /platform/1/auth/groups/GROUP:test_group_create_update HTTP/1.1\n    Host: 10.230.24.249:8080\n    Authorization: root:******\n    \n"
time="2023-07-13T11:11:04+08:00" level=debug msg="\n    -------------------------- GOISILON HTTP RESPONSE -------------------------\n    HTTP/1.1 204 No Content\n    Allow: GET, PUT, DELETE, HEAD\n    Content-Security-Policy: default-src 'self' 'unsafe-inline' 'unsafe-eval' data:; script-src 'self' 'unsafe-eval'; style-src 'unsafe-inline' 'self';\n    Date: Thu, 13 Jul 2023 03:11:03 GMT\n    Server: Apache\n    Strict-Transport-Security: max-age=31536000;\n    X-Content-Type-Options: nosniff\n    X-Frame-Options: sameorigin\n    X-Xss-Protection: 1; mode=block\n    "
--- PASS: TestGroupUpdate (4.40s)
=== RUN   TestGroupMemberAdd
time="2023-07-13T11:11:04+08:00" level=debug msg="\n    -------------------------- GOISILON HTTP REQUEST -------------------------\n    POST /platform/1/auth/groups/ HTTP/1.1\n    Host: 10.230.24.249:8080\n    Authorization: root:******\n    Content-Type: application/json\n    \n    {\"name\":\"test_group_add_member\"}\n"
time="2023-07-13T11:11:04+08:00" level=debug msg="\n    -------------------------- GOISILON HTTP RESPONSE -------------------------\n    HTTP/1.1 201 Created\n    Transfer-Encoding: chunked\n    Allow: GET, POST, DELETE, HEAD\n    Content-Security-Policy: default-src 'self' 'unsafe-inline' 'unsafe-eval' data:; script-src 'self' 'unsafe-eval'; style-src 'unsafe-inline' 'self';\n    Content-Type: application/json\n    Date: Thu, 13 Jul 2023 03:11:03 GMT\n    Location: /1/auth/groups/SID%!A(MISSING)S-1-5-21-2193650305-1279797252-961391754-1159\n    Server: Apache\n    Strict-Transport-Security: max-age=31536000;\n    X-Content-Type-Options: nosniff\n    X-Frame-Options: sameorigin\n    X-Xss-Protection: 1; mode=block\n    "
time="2023-07-13T11:11:04+08:00" level=debug msg="\n    -------------------------- GOISILON HTTP REQUEST -------------------------\n    GET /platform/1/auth/groups/GROUP:test_group_add_member HTTP/1.1\n    Host: 10.230.24.249:8080\n    Authorization: root:******\n    \n"
time="2023-07-13T11:11:05+08:00" level=debug msg="\n    -------------------------- GOISILON HTTP RESPONSE -------------------------\n    HTTP/1.1 200 Ok\n    Transfer-Encoding: chunked\n    Allow: GET, PUT, DELETE, HEAD\n    Content-Security-Policy: default-src 'self' 'unsafe-inline' 'unsafe-eval' data:; script-src 'self' 'unsafe-eval'; style-src 'unsafe-inline' 'self';\n    Content-Type: application/json\n    Date: Thu, 13 Jul 2023 03:11:04 GMT\n    Server: Apache\n    Strict-Transport-Security: max-age=31536000;\n    X-Content-Type-Options: nosniff\n    X-Frame-Options: sameorigin\n    X-Xss-Protection: 1; mode=block\n    "
time="2023-07-13T11:11:05+08:00" level=debug msg="\n    -------------------------- GOISILON HTTP REQUEST -------------------------\n    GET /platform/1/auth/groups/GROUP:test_group_add_member/members/ HTTP/1.1\n    Host: 10.230.24.249:8080\n    Authorization: root:******\n    \n"
time="2023-07-13T11:11:07+08:00" level=debug msg="\n    -------------------------- GOISILON HTTP RESPONSE -------------------------\n    HTTP/1.1 200 Ok\n    Transfer-Encoding: chunked\n    Allow: GET, POST, HEAD\n    Content-Security-Policy: default-src 'self' 'unsafe-inline' 'unsafe-eval' data:; script-src 'self' 'unsafe-eval'; style-src 'unsafe-inline' 'self';\n    Content-Type: application/json\n    Date: Thu, 13 Jul 2023 03:11:06 GMT\n    Server: Apache\n    Strict-Transport-Security: max-age=31536000;\n    X-Content-Type-Options: nosniff\n    X-Frame-Options: sameorigin\n    X-Xss-Protection: 1; mode=block\n    "
time="2023-07-13T11:11:07+08:00" level=debug msg="\n    -------------------------- GOISILON HTTP REQUEST -------------------------\n    POST /platform/1/auth/users/ HTTP/1.1\n    Host: 10.230.24.249:8080\n    Authorization: root:******\n    Content-Type: application/json\n    \n    {\"name\":\"test_user_group_add_member\"}\n"
time="2023-07-13T11:11:08+08:00" level=debug msg="\n    -------------------------- GOISILON HTTP RESPONSE -------------------------\n    HTTP/1.1 201 Created\n    Transfer-Encoding: chunked\n    Allow: GET, POST, DELETE, HEAD\n    Content-Security-Policy: default-src 'self' 'unsafe-inline' 'unsafe-eval' data:; script-src 'self' 'unsafe-eval'; style-src 'unsafe-inline' 'self';\n    Content-Type: application/json\n    Date: Thu, 13 Jul 2023 03:11:07 GMT\n    Location: /1/auth/users/SID%!A(MISSING)S-1-5-21-2193650305-1279797252-961391754-1160\n    Server: Apache\n    Strict-Transport-Security: max-age=31536000;\n    X-Content-Type-Options: nosniff\n    X-Frame-Options: sameorigin\n    X-Xss-Protection: 1; mode=block\n    "
time="2023-07-13T11:11:08+08:00" level=debug msg="\n    -------------------------- GOISILON HTTP REQUEST -------------------------\n    POST /platform/1/auth/groups/GROUP:test_group_add_member/members/ HTTP/1.1\n    Host: 10.230.24.249:8080\n    Authorization: root:******\n    Content-Type: application/json\n    \n    {\"name\":\"test_user_group_add_member\"}\n"
time="2023-07-13T11:11:09+08:00" level=debug msg="\n    -------------------------- GOISILON HTTP RESPONSE -------------------------\n    HTTP/1.1 201 Created\n    Transfer-Encoding: chunked\n    Allow: GET, POST, HEAD\n    Content-Security-Policy: default-src 'self' 'unsafe-inline' 'unsafe-eval' data:; script-src 'self' 'unsafe-eval'; style-src 'unsafe-inline' 'self';\n    Content-Type: application/json\n    Date: Thu, 13 Jul 2023 03:11:08 GMT\n    Location: /1/auth/groups/GROUP:test_group_add_member/members/UID%!A(MISSING)2121\n    Server: Apache\n    Strict-Transport-Security: max-age=31536000;\n    X-Content-Type-Options: nosniff\n    X-Frame-Options: sameorigin\n    X-Xss-Protection: 1; mode=block\n    "
time="2023-07-13T11:11:09+08:00" level=debug msg="\n    -------------------------- GOISILON HTTP REQUEST -------------------------\n    GET /platform/1/auth/groups/GROUP:test_group_add_member/members/ HTTP/1.1\n    Host: 10.230.24.249:8080\n    Authorization: root:******\n    \n"
time="2023-07-13T11:11:10+08:00" level=debug msg="\n    -------------------------- GOISILON HTTP RESPONSE -------------------------\n    HTTP/1.1 200 Ok\n    Transfer-Encoding: chunked\n    Allow: GET, POST, HEAD\n    Content-Security-Policy: default-src 'self' 'unsafe-inline' 'unsafe-eval' data:; script-src 'self' 'unsafe-eval'; style-src 'unsafe-inline' 'self';\n    Content-Type: application/json\n    Date: Thu, 13 Jul 2023 03:11:09 GMT\n    Server: Apache\n    Strict-Transport-Security: max-age=31536000;\n    X-Content-Type-Options: nosniff\n    X-Frame-Options: sameorigin\n    X-Xss-Protection: 1; mode=block\n    "
time="2023-07-13T11:11:10+08:00" level=debug msg="\n    -------------------------- GOISILON HTTP REQUEST -------------------------\n    DELETE /platform/1/auth/groups/GROUP:test_group_add_member/members/USER:test_user_group_add_member HTTP/1.1\n    Host: 10.230.24.249:8080\n    Authorization: root:******\n    \n"
time="2023-07-13T11:11:12+08:00" level=debug msg="\n    -------------------------- GOISILON HTTP RESPONSE -------------------------\n    HTTP/1.1 204 No Content\n    Allow: DELETE, HEAD\n    Content-Security-Policy: default-src 'self' 'unsafe-inline' 'unsafe-eval' data:; script-src 'self' 'unsafe-eval'; style-src 'unsafe-inline' 'self';\n    Date: Thu, 13 Jul 2023 03:11:10 GMT\n    Server: Apache\n    Strict-Transport-Security: max-age=31536000;\n    X-Content-Type-Options: nosniff\n    X-Frame-Options: sameorigin\n    X-Xss-Protection: 1; mode=block\n    "
time="2023-07-13T11:11:12+08:00" level=debug msg="\n    -------------------------- GOISILON HTTP REQUEST -------------------------\n    GET /platform/1/auth/groups/GROUP:test_group_add_member/members/ HTTP/1.1\n    Host: 10.230.24.249:8080\n    Authorization: root:******\n    \n"
time="2023-07-13T11:11:12+08:00" level=debug msg="\n    -------------------------- GOISILON HTTP RESPONSE -------------------------\n    HTTP/1.1 200 Ok\n    Transfer-Encoding: chunked\n    Allow: GET, POST, HEAD\n    Content-Security-Policy: default-src 'self' 'unsafe-inline' 'unsafe-eval' data:; script-src 'self' 'unsafe-eval'; style-src 'unsafe-inline' 'self';\n    Content-Type: application/json\n    Date: Thu, 13 Jul 2023 03:11:11 GMT\n    Server: Apache\n    Strict-Transport-Security: max-age=31536000;\n    X-Content-Type-Options: nosniff\n    X-Frame-Options: sameorigin\n    X-Xss-Protection: 1; mode=block\n    "
time="2023-07-13T11:11:12+08:00" level=debug msg="\n    -------------------------- GOISILON HTTP REQUEST -------------------------\n    DELETE /platform/1/auth/users/USER:test_user_group_add_member HTTP/1.1\n    Host: 10.230.24.249:8080\n    Authorization: root:******\n    \n"
time="2023-07-13T11:11:13+08:00" level=debug msg="\n    -------------------------- GOISILON HTTP RESPONSE -------------------------\n    HTTP/1.1 204 No Content\n    Allow: GET, PUT, DELETE, HEAD\n    Content-Security-Policy: default-src 'self' 'unsafe-inline' 'unsafe-eval' data:; script-src 'self' 'unsafe-eval'; style-src 'unsafe-inline' 'self';\n    Date: Thu, 13 Jul 2023 03:11:12 GMT\n    Server: Apache\n    Strict-Transport-Security: max-age=31536000;\n    X-Content-Type-Options: nosniff\n    X-Frame-Options: sameorigin\n    X-Xss-Protection: 1; mode=block\n    "
time="2023-07-13T11:11:13+08:00" level=debug msg="\n    -------------------------- GOISILON HTTP REQUEST -------------------------\n    DELETE /platform/1/auth/groups/GROUP:test_group_add_member HTTP/1.1\n    Host: 10.230.24.249:8080\n    Authorization: root:******\n    \n"
time="2023-07-13T11:11:14+08:00" level=debug msg="\n    -------------------------- GOISILON HTTP RESPONSE -------------------------\n    HTTP/1.1 204 No Content\n    Allow: GET, PUT, DELETE, HEAD\n    Content-Security-Policy: default-src 'self' 'unsafe-inline' 'unsafe-eval' data:; script-src 'self' 'unsafe-eval'; style-src 'unsafe-inline' 'self';\n    Date: Thu, 13 Jul 2023 03:11:13 GMT\n    Server: Apache\n    Strict-Transport-Security: max-age=31536000;\n    X-Content-Type-Options: nosniff\n    X-Frame-Options: sameorigin\n    X-Xss-Protection: 1; mode=block\n    "
--- PASS: TestGroupMemberAdd (9.81s)
PASS
ok      github.com/dell/goisilon        28.208s
```