### PR TITLE
KRV-26417: Gosec issues skipped

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -47,7 +47,7 @@ const (
 	defaultVolumesPathPermissions         = "0777"
 	defaultIgnoreUnresolvableHosts        = false
 	headerISISessToken                    = "Cookie"
-	headerISICSRFToken                    = "X-CSRF-Token" //nolint:gosec,G101
+	headerISICSRFToken                    = "X-CSRF-Token" // #nosec, G101  False positive since no hard-coded CSRF token
 	headerISIReferer                      = "Referer"
 	isiSessCsrfToken                      = "Set-Cookie"
 	authTypeBasic                         = 0
@@ -266,7 +266,7 @@ func New(
 		if opts.Insecure {
 			c.http.Transport = &http.Transport{
 				TLSClientConfig: &tls.Config{
-					InsecureSkipVerify: true, //nolint:gosec,G402
+					InsecureSkipVerify: true, // #nosec,G402
 					MinVersion:         tls.VersionTLS12,
 					MaxVersion:         tls.VersionTLS13,
 					CipherSuites:       GetSecuredCipherSuites(),


### PR DESCRIPTION
# PR Submission checklist
Gosec issues skipped 
CWE-798 :  This one is false positive since there is no hardcoded content it is just a string
CWE-295 : We can't set InsecureSkipVerify as false or true always, anyways we are overriding the value later based on user input

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
| KRV-26417|

# Common PR Checklist:

- [x] Have you made sure that the code compiles?
- [x] Have you commented your code, particularly in hard-to-understand areas
- [x] Did you run tests in a real Kubernetes cluster?
- [x] Have you maintained backward compatibility

## Description of your changes:
<your change goes here>

Results:


Summary:
  Gosec  : dev
  Files  : 71
  Lines  : 15193
  Nosec  : 2
  Issues : 0